### PR TITLE
fix: the DHCPServerBuffers and DHCPServerSocket were introduced

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leasehund"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 authors = ["rttf <contact@rttf.dev>"]
 description = "A lightweight, embedded-friendly DHCP server implementation for Rust no_std environments"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,9 @@ smoltcp = { version = "0.12.0", default-features = false, features = [
     "proto-dhcpv4",
     "socket-udp",
 ] }
+defmt = { version = "1.0", optional = true }
+
+[features]
+defmt = ["dep:defmt"]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ keywords = ["dhcp", "embedded", "no-std", "networking", "embassy"]
 readme = "README.md"
 
 [dependencies]
-embassy-net = { version = "0.7.0", features = [
+embassy-net = { version = "0.7.1", features = [
     "tcp",
     "udp",
     "dhcpv4",
     "medium-ethernet",
     "proto-ipv4",
 ] }
-embassy-time = "0.4.0"
+embassy-time = "0.5.0"
 heapless = "0.8.0"
 smoltcp = { version = "0.12.0", default-features = false, features = [
     "proto-ipv4",
@@ -29,6 +29,6 @@ smoltcp = { version = "0.12.0", default-features = false, features = [
 defmt = { version = "1.0", optional = true }
 
 [features]
-defmt = ["dep:defmt"]
+defmt = ["dep:defmt", "embassy-net/defmt"]
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ async fn main(_spawner: Spawner) {
 
 The DHCP server requires the following configuration parameters:
 
-| Parameter | Description | Example |
-|-----------|-------------|---------|
-| `server_ip` | IP address of the DHCP server | `192.168.1.1` |
-| `subnet_mask` | Network subnet mask | `255.255.255.0` |
-| `router` | Default gateway IP address | `192.168.1.1` |
-| `dns_server` | DNS server IP address | `8.8.8.8` |
+| Parameter       | Description                      | Example         |
+| --------------- | -------------------------------- | --------------- |
+| `server_ip`     | IP address of the DHCP server    | `192.168.1.1`   |
+| `subnet_mask`   | Network subnet mask              | `255.255.255.0` |
+| `router`        | Default gateway IP address       | `192.168.1.1`   |
+| `dns_server`    | DNS server IP address            | `8.8.8.8`       |
 | `ip_pool_start` | First IP in the assignable range | `192.168.1.100` |
-| `ip_pool_end` | Last IP in the assignable range | `192.168.1.200` |
+| `ip_pool_end`   | Last IP in the assignable range  | `192.168.1.200` |
 
 ### Advanced Configuration
 
@@ -105,11 +105,11 @@ let server: DhcpServer<32, 4> = DhcpServer::with_config(config);
 
 ## Supported DHCP Messages
 
-| Message Type | Description | Server Response |
-|--------------|-------------|-----------------|
-| **DISCOVER** | Client broadcast to find DHCP servers | **OFFER** with available IP |
-| **REQUEST** | Client request for specific IP address | **ACK** confirming lease |
-| **RELEASE** | Client releasing IP address | Lease removal (no response) |
+| Message Type | Description                            | Server Response             |
+| ------------ | -------------------------------------- | --------------------------- |
+| **DISCOVER** | Client broadcast to find DHCP servers  | **OFFER** with available IP |
+| **REQUEST**  | Client request for specific IP address | **ACK** confirming lease    |
+| **RELEASE**  | Client releasing IP address            | Lease removal (no response) |
 
 ## DHCP Options Supported
 
@@ -122,6 +122,56 @@ The server automatically includes these standard DHCP options in responses:
 - **Option 53**: DHCP Message Type
 - **Option 54**: Server Identifier
 
+
+## Advanced uscase
+
+In case you need to handle lease/release events of each new client you can use the `lease_one` method:
+
+```rust
+use core::net::Ipv4Addr;
+use leasehund::{DhcpServer, DHCPServerSocket, TransactionEvent};
+use embassy_net::Stack;
+use core::net::Ipv4Addr;
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    // Initialize your embassy network stack here
+    let stack = /* ... your network stack initialization ... */;
+    
+    let config: DhcpConfig<4> = DhcpConfigBuilder::new()
+        .server_ip(Ipv4Addr::new(10, 0, 1, 1))
+        .subnet_mask(Ipv4Addr::new(255, 255, 0, 0))
+        .router(Ipv4Addr::new(10, 0, 1, 1))
+        .add_dns_server(Ipv4Addr::new(1, 1, 1, 1))      // Cloudflare DNS
+        .add_dns_server(Ipv4Addr::new(1, 0, 0, 1))      // Cloudflare backup
+        .add_dns_server(Ipv4Addr::new(8, 8, 8, 8))      // Google DNS
+        .ip_pool(
+            Ipv4Addr::new(10, 0, 100, 1),
+            Ipv4Addr::new(10, 0, 199, 254)
+        )
+        .lease_time(7200)    // 2 hours
+        .build();
+    
+    let mut dhcp_server: DhcpServer<32, 4> = DhcpServer::with_config(config);
+    let mut buffers = DHCPServerBuffers::new();
+    let mut socket = DHCPServerSocket::new(stack, &mut buffers);
+    loop {
+        let Ok(event) = server.lease_one(&socket).await else {
+            // Handle error (e.g., log it)
+            continue;
+        };
+
+        match event {
+            TransactionEvent::Leased(ip, mac) => {
+                info!("Leased IP: {} to MAC: {:02x?}", ip, mac);
+            }
+            TransactionEvent::Released(ip, mac) => {
+                info!("Released IP: {} from MAC: {:02x?}", ip, mac);
+            }
+        }
+    }
+}
+```
 
 ## Protocol Compliance
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,52 @@
 //! - IPv4 address (4 bytes)
 //! - MAC address (6 bytes)  
 //! - Lease expiration timestamp (8 bytes)
+//!
+//! ## Advanced Usage
+//!
+//! For the case you want to handle each transaction manually, you can use the `lease_one` method.
+//! This allows you to handle each DHCP transaction individually, giving you more control over the process.
+//! For instance, you might want to log each transaction or implement custom logic based on the transaction type.
+//! Here's an example of how to use `lease_one`:
+//! ```rust,no_run
+//! use core::net::Ipv4Addr;
+//! use leasehund::{DhcpServer, DHCPServerSocket, TransactionEvent};
+//! use embassy_net::Stack;
+//! use embassy_net::udp::UdpSocket;
+//! use embassy_time::Duration;
+//!
+//! # async fn example(stack: Stack<'static>) {
+//!     let config: DhcpConfig<4> = DhcpConfigBuilder::new()
+//!         .server_ip(Ipv4Addr::new(10, 0, 1, 1))
+//!         .subnet_mask(Ipv4Addr::new(255, 255, 0, 0))
+//!         .router(Ipv4Addr::new(10, 0, 1, 1))
+//!         .add_dns_server(Ipv4Addr::new(1, 1, 1, 1))      // Cloudflare DNS
+//!         .add_dns_server(Ipv4Addr::new(1, 0, 0, 1))      // Cloudflare backup
+//!         .add_dns_server(Ipv4Addr::new(8, 8, 8, 8))      // Google DNS
+//!         .ip_pool(
+//!             Ipv4Addr::new(10, 0, 100, 1),
+//!             Ipv4Addr::new(10, 0, 199, 254)
+//!         )
+//!         .lease_time(7200)    // 2 hours
+//!         .build();
+//!     let mut dhcp_server: DhcpServer<32, 4> = DhcpServer::with_config(config);
+//!     let mut buffers = DHCPServerBuffers::new();
+//!     let mut socket = DHCPServerSocket::new(stack, &mut buffers);
+//!     loop {
+//!         let Ok(event) = server.lease_one(&socket).await else {
+//!             // Handle error (e.g., log it)
+//!             continue;
+//!         };
+//!         match event {
+//!             TransactionEvent::Leased(ip, mac) => {
+//!                 info!("Leased IP: {} to MAC: {:02x?}", ip, mac);
+//!             }
+//!             TransactionEvent::Released(ip, mac) => {
+//!                 info!("Released IP: {} from MAC: {:02x?}", ip, mac);
+//!             }
+//!         }
+//!     }
+//! # }
 
 #![no_std]
 #![warn(missing_docs)]
@@ -116,10 +162,13 @@
 
 use core::net::Ipv4Addr;
 use embassy_net::Stack;
-use embassy_net::udp::{BindError, PacketMetadata, UdpSocket};
+use embassy_net::udp::{PacketMetadata, UdpSocket};
 use embassy_time::{Duration, Timer};
 use heapless::Vec;
 use smoltcp::phy::PacketMeta;
+
+/// Reexported types from Embassy for convenience
+pub use embassy_net::udp::RecvError;
 
 /// Standard DHCP server port (RFC 2131)
 const DHCP_SERVER_PORT: u16 = 67;
@@ -405,6 +454,7 @@ impl Default for DhcpPacket {
 /// Used internally by the DHCP server to track active leases.
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct LeaseEntry {
     /// The IP address assigned to the client
     ip: Ipv4Addr,
@@ -433,6 +483,7 @@ impl DHCPServerBuffers {
     /// let mut buffers = DHCPServerBuffers::new();
     /// ```
     ///
+    #[must_use]
     pub const fn new() -> Self {
         Self {
             rx_buffer: [0; DEFAULT_SOCKET_BUFFER_SIZE],
@@ -443,8 +494,35 @@ impl DHCPServerBuffers {
     }
 }
 
-/// Wrapper around the Embassy UDP socket for DHCP server use
-/// with associated buffers
+impl Default for DHCPServerBuffers {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Represents a DHCP lease/release event
+/// Used for logging and monitoring lease assignments and releases
+///
+/// - **Leased** - indicates a new lease assignment
+///
+/// - **Released** - indicates a release the IP by a client
+///   Each event includes the relevant IP address and client MAC address
+/// # Examples
+/// ```rust
+/// use leasehund::TransactionEvent;
+/// use core::net::Ipv4Addr;
+/// let event = TransactionEvent::Leased(Ipv4Addr::new(192, 168, 1, 100), [0x00, 0x11, 0x22, 0x33, 0x44, 0x55]);    
+/// ```
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TransactionEvent {
+    /// Indicates a new lease assignment
+    Leased(Ipv4Addr, [u8; 6]),
+    /// Indicates a release the IP by a client
+    Released(Ipv4Addr, [u8; 6]),
+}
+
+/// Wrapper around the Embassy UDP socket for DHCP server use.
 pub struct DHCPServerSocket<'a> {
     socket: UdpSocket<'a>,
 }
@@ -452,7 +530,6 @@ pub struct DHCPServerSocket<'a> {
 impl<'a> DHCPServerSocket<'a> {
     /// Creates a new DHCP server UDP socket bound to the standard DHCP server port (67)
     /// using the provided Embassy network stack and pre-allocated buffers.
-    /// The socket is configured to send responses to the DHCP client port (68).
     /// # Arguments
     /// * `stack` - The Embassy network stack to use for the socket
     /// * `buffers` - Pre-allocated buffers for the UDP socket
@@ -468,22 +545,17 @@ impl<'a> DHCPServerSocket<'a> {
     /// let socket = DHCPServerSocket::new(stack, &mut buffers);
     /// ```
     ///
+    #[must_use]
     pub fn new(stack: Stack<'a>, buffers: &'a mut DHCPServerBuffers) -> Self {
-        let socket = UdpSocket::new(
+        let mut socket = UdpSocket::new(
             stack,
             &mut buffers.rx_meta,
             &mut buffers.rx_buffer,
             &mut buffers.tx_meta,
             &mut buffers.tx_buffer,
         );
+        socket.bind(DHCP_SERVER_PORT).unwrap();
         Self { socket }
-    }
-
-    /// Binds the UDP socket to the DHCP server port (67)
-    /// # Returns
-    /// `Ok(())` if binding was successful, or a `BindError` if it failed
-    fn bind(&mut self) -> Result<(), BindError> {
-        self.socket.bind(DHCP_SERVER_PORT)
     }
 }
 
@@ -746,6 +818,7 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     ///
     /// let server: DhcpServer<32, 4> = DhcpServer::with_config(config);
     /// ```
+
     /// Finds the next available IP address in the configured pool
     ///
     /// Iterates through the IP address range from `ip_pool_start` to `ip_pool_end`
@@ -943,13 +1016,17 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     /// * `socket` - UDP socket for sending responses
     /// * `data` - Raw packet data received from client
     #[allow(clippy::future_not_send)]
-    async fn handle_packet(&mut self, socket: &DHCPServerSocket<'_>, data: &[u8]) {
+    async fn handle_packet(
+        &mut self,
+        socket: &DHCPServerSocket<'_>,
+        data: &[u8],
+    ) -> Option<TransactionEvent> {
         if data.len() < core::mem::size_of::<DhcpPacket>() {
-            return;
+            return None;
         }
         let packet = unsafe { &*data.as_ptr().cast::<DhcpPacket>() };
         if packet.magic != DHCP_MAGIC {
-            return;
+            return None;
         }
         let options = &data[core::mem::size_of::<DhcpPacket>()..];
         if let Some(msg_type) = Self::parse_message_type(options) {
@@ -962,6 +1039,7 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
                         meta: PacketMeta::default(),
                     };
                     let _ = socket.socket.send_to(&resp, meta).await;
+                    return None;
                 }
                 DHCP_REQUEST => {
                     let resp = self.make_response(packet, DHCP_ACK);
@@ -971,12 +1049,80 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
                         meta: PacketMeta::default(),
                     };
                     let _ = socket.socket.send_to(&resp, meta).await;
+                    let mac: [u8; 6] = packet.chaddr[..6].try_into().unwrap_or([0; 6]);
+                    return self
+                        .leases
+                        .get(&mac)
+                        .map(|entry| TransactionEvent::Leased(entry.ip, mac));
                 }
                 DHCP_RELEASE => {
                     let mac: [u8; 6] = packet.chaddr[..6].try_into().unwrap_or([0; 6]);
-                    self.leases.remove(&mac);
+                    let entry = self.leases.remove(&mac);
+                    return entry.map(|entry| TransactionEvent::Released(entry.ip, entry.mac));
                 }
-                _ => {}
+                _ => {
+                    return None;
+                }
+            }
+        }
+        None
+    }
+
+    /// Runs the DHCP server until a single lease/release transaction occurs
+    /// This function listens for incoming DHCP packets and processes them.
+    /// It is typically called in a loop to handle multiple lease/release transactions.
+    /// # Arguments
+    /// * `socket` - The DHCPServerSocket which is actually a properly configured UDP socket to listen on for DHCP packets
+    /// # Returns
+    /// - Ok([`TransactionEvent`]) if a transaction was successfully processed [`pin!`]
+    /// - Err([`RecvError`]) if there was an error of receiving a packet
+    /// # Examples
+    /// ```rust,no_run
+    /// use leasehund::{DhcpServer, DHCPServerBuffers, DHCPServerSocket, TransactionEvent};
+    /// use embassy_net::Stack;
+    /// # async fn example(stack: Stack<'static>) {
+    /// let mut server = DhcpServer::<32, 4>::new(
+    ///     Ipv4Addr::new(192, 168, 1, 1),
+    ///     Ipv4Addr::new(255, 255, 255, 0),
+    ///     Ipv4Addr::new(192, 168,1, 1),
+    ///     Ipv4Addr::new(8, 8, 8, 8),
+    ///     Ipv4Addr::new(192, 168, 1, 100),
+    ///     Ipv4Addr::new(192, 168, 1, 200),
+    /// );
+    /// let mut buffers = DHCPServerBuffers::new();
+    /// let mut socket = DHCPServerSocket::new(stack, &mut buffers);
+    /// loop {
+    ///     let Ok(event) = server.lease_one(&socket).await else {
+    ///         // Handle error (e.g., log it)
+    ///         continue;
+    ///     };
+    ///     match event {
+    ///         TransactionEvent::Leased(ip, mac) => {
+    ///             info!("Leased IP: {} to MAC: {:02x?}", ip, mac);
+    ///         }
+    ///         TransactionEvent::Released(ip, mac) => {
+    ///             info!("Released IP: {} from MAC: {:02x?}", ip, mac);
+    ///         }
+    ///     }
+    /// # }
+    /// ```
+    #[allow(clippy::future_not_send)]
+    pub async fn lease_one(
+        &mut self,
+        socket: &mut DHCPServerSocket<'_>,
+    ) -> Result<TransactionEvent, RecvError> {
+        loop {
+            let mut buf = [0u8; 576];
+            match socket.socket.recv_from(&mut buf).await {
+                Ok((len, _)) => {
+                    if let Some(event) = self.handle_packet(socket, &buf[..len]).await {
+                        // Ensure all data is flushed to the network
+                        socket.socket.flush().await;
+                        return Ok(event);
+                    }
+                }
+
+                Err(e) => return Err(e),
             }
         }
     }
@@ -1029,13 +1175,13 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     #[allow(clippy::future_not_send)]
     pub async fn run(&mut self, stack: Stack<'_>) -> ! {
         let mut buffers = DHCPServerBuffers::new();
-        let mut socket = DHCPServerSocket::new(stack, &mut buffers);
-        socket.bind().unwrap();
-
+        let socket = DHCPServerSocket::new(stack, &mut buffers);
         loop {
             let mut buf = [0u8; 576];
             match socket.socket.recv_from(&mut buf).await {
-                Ok((len, _)) => self.handle_packet(&socket, &buf[..len]).await,
+                Ok((len, _)) => {
+                    let _ = self.handle_packet(&socket, &buf[..len]).await;
+                }
                 Err(_) => Timer::after(Duration::from_millis(100)).await,
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -792,8 +792,7 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     /// Checks if the IP pool is full
     #[must_use]
     pub fn is_pool_full(&self) -> bool {
-        let pool_size =
-            u32::from(self.config.ip_pool_end) - u32::from(self.config.ip_pool_start) + 1;
+        let pool_size = u32::from(self.config.ip_pool_end) - u32::from(self.config.ip_pool_start) + 1;
         self.leases.len() >= (pool_size as usize).min(MAX_CLIENTS)
     }
 
@@ -886,17 +885,11 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     /// * `packet` - Mutable reference to the packet buffer
     /// * `msg_type` - DHCP message type to include in options
     fn add_options(&self, packet: &mut Vec<u8, DHCP_PACKET_SIZE>, msg_type: u8) {
-        packet
-            .extend_from_slice(&[OPTION_MESSAGE_TYPE, 1, msg_type])
-            .ok();
+        packet.extend_from_slice(&[OPTION_MESSAGE_TYPE, 1, msg_type]).ok();
         packet.extend_from_slice(&[OPTION_SERVER_ID, 4]).ok();
-        packet
-            .extend_from_slice(&self.config.server_ip.octets())
-            .ok();
+        packet.extend_from_slice(&self.config.server_ip.octets()).ok();
         packet.extend_from_slice(&[OPTION_SUBNET_MASK, 4]).ok();
-        packet
-            .extend_from_slice(&self.config.subnet_mask.octets())
-            .ok();
+        packet.extend_from_slice(&self.config.subnet_mask.octets()).ok();
 
         // Add router option if configured
         if let Some(router) = self.config.router {
@@ -908,18 +901,14 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
         if !self.config.dns_servers.is_empty() {
             let dns_count = self.config.dns_servers.len() * 4; // 4 bytes per IP
             let dns_count_u8 = u8::try_from(dns_count).unwrap_or_default();
-            packet
-                .extend_from_slice(&[OPTION_DNS_SERVER, dns_count_u8])
-                .ok();
+            packet.extend_from_slice(&[OPTION_DNS_SERVER, dns_count_u8]).ok();
             for dns in &self.config.dns_servers {
                 packet.extend_from_slice(&dns.octets()).ok();
             }
         }
 
         packet.extend_from_slice(&[OPTION_LEASE_TIME, 4]).ok();
-        packet
-            .extend_from_slice(&self.config.lease_time.to_be_bytes())
-            .ok();
+        packet.extend_from_slice(&self.config.lease_time.to_be_bytes()).ok();
         packet.extend_from_slice(&[OPTION_END]).ok();
     }
 
@@ -971,10 +960,8 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
         }
         let mut bytes = Vec::<u8, DHCP_PACKET_SIZE>::new();
         unsafe {
-            let resp_bytes = core::slice::from_raw_parts(
-                (&raw const resp).cast::<u8>(),
-                core::mem::size_of::<DhcpPacket>(),
-            );
+            let resp_bytes =
+                core::slice::from_raw_parts((&raw const resp).cast::<u8>(), core::mem::size_of::<DhcpPacket>());
             bytes.extend_from_slice(resp_bytes).ok();
         }
         self.add_options(&mut bytes, msg_type);
@@ -993,11 +980,7 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     /// * `socket` - UDP socket for sending responses
     /// * `data` - Raw packet data received from client
     #[allow(clippy::future_not_send)]
-    async fn handle_packet(
-        &mut self,
-        socket: &DHCPServerSocket<'_>,
-        data: &[u8],
-    ) -> Option<TransactionEvent> {
+    async fn handle_packet(&mut self, socket: &DHCPServerSocket<'_>, data: &[u8]) -> Option<TransactionEvent> {
         if data.len() < core::mem::size_of::<DhcpPacket>() {
             return None;
         }
@@ -1089,10 +1072,7 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     /// ```
     ///
     #[allow(clippy::future_not_send)]
-    pub async fn lease_one(
-        &mut self,
-        socket: &mut DHCPServerSocket<'_>,
-    ) -> Result<TransactionEvent, RecvError> {
+    pub async fn lease_one(&mut self, socket: &mut DHCPServerSocket<'_>) -> Result<TransactionEvent, RecvError> {
         loop {
             let mut buf = [0u8; DHCP_PACKET_SIZE];
             match socket.socket.recv_from(&mut buf).await {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,41 +118,42 @@
 //! use core::net::Ipv4Addr;
 //! use leasehund::{DhcpServer, DHCPServerSocket, TransactionEvent};
 //! use embassy_net::Stack;
-//! use embassy_net::udp::UdpSocket;
-//! use embassy_time::Duration;
+//! use core::net::Ipv4Addr;
 //!
 //! # async fn example(stack: Stack<'static>) {
-//!     let config: DhcpConfig<4> = DhcpConfigBuilder::new()
-//!         .server_ip(Ipv4Addr::new(10, 0, 1, 1))
-//!         .subnet_mask(Ipv4Addr::new(255, 255, 0, 0))
-//!         .router(Ipv4Addr::new(10, 0, 1, 1))
-//!         .add_dns_server(Ipv4Addr::new(1, 1, 1, 1))      // Cloudflare DNS
-//!         .add_dns_server(Ipv4Addr::new(1, 0, 0, 1))      // Cloudflare backup
-//!         .add_dns_server(Ipv4Addr::new(8, 8, 8, 8))      // Google DNS
-//!         .ip_pool(
-//!             Ipv4Addr::new(10, 0, 100, 1),
-//!             Ipv4Addr::new(10, 0, 199, 254)
-//!         )
-//!         .lease_time(7200)    // 2 hours
-//!         .build();
-//!     let mut dhcp_server: DhcpServer<32, 4> = DhcpServer::with_config(config);
-//!     let mut buffers = DHCPServerBuffers::new();
-//!     let mut socket = DHCPServerSocket::new(stack, &mut buffers);
-//!     loop {
-//!         let Ok(event) = server.lease_one(&socket).await else {
-//!             // Handle error (e.g., log it)
-//!             continue;
-//!         };
-//!         match event {
-//!             TransactionEvent::Leased(ip, mac) => {
-//!                 info!("Leased IP: {} to MAC: {:02x?}", ip, mac);
-//!             }
-//!             TransactionEvent::Released(ip, mac) => {
-//!                 info!("Released IP: {} from MAC: {:02x?}", ip, mac);
-//!             }
+//! let config: DhcpConfig<4> = DhcpConfigBuilder::new()
+//!     .server_ip(Ipv4Addr::new(10, 0, 1, 1))
+//!     .subnet_mask(Ipv4Addr::new(255, 255, 0, 0))
+//!     .router(Ipv4Addr::new(10, 0, 1, 1))
+//!     .add_dns_server(Ipv4Addr::new(1, 1, 1, 1))      // Cloudflare DNS
+//!     .add_dns_server(Ipv4Addr::new(1, 0, 0, 1))      // Cloudflare backup
+//!     .add_dns_server(Ipv4Addr::new(8, 8, 8, 8))      // Google DNS
+//!     .ip_pool(
+//!         Ipv4Addr::new(10, 0, 100, 1),
+//!         Ipv4Addr::new(10, 0, 199, 254)
+//!     )
+//!     .lease_time(7200)    // 2 hours
+//!     .build();
+//! let mut dhcp_server: DhcpServer<32, 4> = DhcpServer::with_config(config);
+//! let mut buffers = DHCPServerBuffers::new();
+//! let mut socket = DHCPServerSocket::new(stack, &mut buffers);
+//! loop {
+//!     let Ok(event) = server.lease_one(&socket).await else {
+//!         // Handle error (e.g., log it)
+//!         continue;
+//!     };
+//!     match event {
+//!         TransactionEvent::Leased(ip, mac) => {
+//!             info!("Leased IP: {} to MAC: {:02x?}", ip, mac);
+//!         }
+//!         TransactionEvent::Released(ip, mac) => {
+//!             info!("Released IP: {} from MAC: {:02x?}", ip, mac);
 //!         }
 //!     }
+//! }
 //! # }
+//! ```
+//!
 
 #![no_std]
 #![warn(missing_docs)]
@@ -447,9 +448,13 @@ impl Default for DhcpPacket {
         }
     }
 }
+/// The total size of a fixed part the DHCP packet
 const FIXED_PART_SIZE: usize = core::mem::size_of::<DhcpPacket>();
+/// Size of the END option (1 byte)
 const END_OPTIONS_MARK_SIZE: usize = 1; // Size of the END option
-const OPTIONS_SIZE: usize = 335; // The maximum DHCP options field size used by this implementation
+/// The maximum DHCP options field size used by this implementation
+const OPTIONS_SIZE: usize = 335;
+/// Total DHCP packet size (fixed part + options + END option)
 const DHCP_PACKET_SIZE: usize = FIXED_PART_SIZE + OPTIONS_SIZE + END_OPTIONS_MARK_SIZE;
 
 /// Represents a DHCP lease entry for a client
@@ -528,6 +533,7 @@ pub enum TransactionEvent {
 
 /// Wrapper around the Embassy UDP socket for DHCP server use.
 pub struct DHCPServerSocket<'a> {
+    /// The underlying Embassy UDP socket
     socket: UdpSocket<'a>,
 }
 
@@ -539,6 +545,8 @@ impl<'a> DHCPServerSocket<'a> {
     /// * `buffers` - Pre-allocated buffers for the UDP socket
     /// # Returns
     /// A new `DHCPServerSocket` instance
+    /// # Panics
+    /// This function will panic if the socket binding fails.
     ///
     /// # Examples
     /// ```rust
@@ -645,7 +653,8 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     ///     Ipv4Addr::new(192, 168, 1, 100),  // Pool start
     ///     Ipv4Addr::new(192, 168, 1, 200),  // Pool end
     /// );
-    /// ```    #[must_use]
+    /// ```
+    ///
     #[must_use]
     pub const fn new(
         server_ip: Ipv4Addr,
@@ -819,7 +828,6 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     /// let server: DhcpServer<32, 4> = DhcpServer::with_config(config);
     /// let next = server.get_next_available_ip();
     /// assert!(matches!(next, Some(ip) if ip == Ipv4Addr::new(10, 0, 0, 100)));
-    ///
     /// ```
     pub fn get_next_available_ip(&self) -> Option<Ipv4Addr> {
         let start = u32::from(self.config.ip_pool_start);
@@ -1041,19 +1049,22 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     /// This function listens for incoming DHCP packets and processes them.
     /// It is typically called in a loop to handle multiple lease/release transactions.
     /// # Arguments
-    /// * `socket` - The DHCPServerSocket which is actually a properly configured UDP socket to listen on for DHCP packets
+    /// * `socket` - The `DHCPServerSocket` which is actually a properly configured UDP socket to listen on for DHCP packets
     /// # Returns
-    /// - Ok([`TransactionEvent`]) if a transaction was successfully processed [`pin!`]
+    /// - Ok([`TransactionEvent`]) if a transaction was successfully processed
+    /// # Errors
     /// - Err([`RecvError`]) if there was an error of receiving a packet
     /// # Examples
-    /// ```rust,no_run
+    /// ```rust, no_run
     /// use leasehund::{DhcpServer, DHCPServerBuffers, DHCPServerSocket, TransactionEvent};
     /// use embassy_net::Stack;
+    /// use core::net::Ipv4Addr;
+    ///
     /// # async fn example(stack: Stack<'static>) {
     /// let mut server = DhcpServer::<32, 4>::new(
     ///     Ipv4Addr::new(192, 168, 1, 1),
     ///     Ipv4Addr::new(255, 255, 255, 0),
-    ///     Ipv4Addr::new(192, 168,1, 1),
+    ///     Ipv4Addr::new(192, 168, 1, 1),
     ///     Ipv4Addr::new(8, 8, 8, 8),
     ///     Ipv4Addr::new(192, 168, 1, 100),
     ///     Ipv4Addr::new(192, 168, 1, 200),
@@ -1070,11 +1081,13 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     ///             info!("Leased IP: {} to MAC: {:02x?}", ip, mac);
     ///         }
     ///         TransactionEvent::Released(ip, mac) => {
-    ///             info!("Released IP: {} from MAC: {:02x?}", ip, mac);
+    ///            info!("Released IP: {} from MAC: {:02x?}", ip, mac);
     ///         }
-    ///     }
+    ///    }
+    /// }
     /// # }
     /// ```
+    ///
     #[allow(clippy::future_not_send)]
     pub async fn lease_one(
         &mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -784,41 +784,6 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
         self.leases.len() >= (pool_size as usize).min(MAX_CLIENTS)
     }
 
-    /// Creates a new DHCP server with the specified configuration
-    ///
-    /// # Arguments
-    ///
-    /// * `config` - A `DhcpConfig` structure containing the desired configuration
-    ///
-    /// # Returns
-    ///
-    /// A new `DhcpServer` instance ready to handle DHCP requests
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use core::net::Ipv4Addr;
-    /// use leasehund::{DhcpConfig, DhcpServer};
-    /// use heapless::Vec;
-    ///
-    /// let mut dns_servers = heapless::Vec::<core::net::Ipv4Addr, 4>::new();
-    /// dns_servers.push(core::net::Ipv4Addr::new(8, 8, 8, 8)).ok();
-    /// dns_servers.push(core::net::Ipv4Addr::new(8, 8, 4, 4)).ok();
-    ///
-    /// let config: DhcpConfig<4> = DhcpConfig {
-    ///     server_ip: Ipv4Addr::new(192, 168, 1, 1),
-    ///     subnet_mask: Ipv4Addr::new(255, 255, 255, 0),
-    ///     router: Some(Ipv4Addr::new(192, 168, 1, 1)),
-    ///     dns_servers,
-    ///     ip_pool_start: Ipv4Addr::new(192, 168, 1, 100),
-    ///     ip_pool_end: Ipv4Addr::new(192, 168, 1, 200),
-    ///     lease_time: 3600, // 1 hour
-    ///     socket_buffer_size: 1024,
-    /// };
-    ///
-    /// let server: DhcpServer<32, 4> = DhcpServer::with_config(config);
-    /// ```
-
     /// Finds the next available IP address in the configured pool
     ///
     /// Iterates through the IP address range from `ip_pool_start` to `ip_pool_end`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,6 +447,10 @@ impl Default for DhcpPacket {
         }
     }
 }
+const FIXED_PART_SIZE: usize = core::mem::size_of::<DhcpPacket>();
+const END_OPTIONS_MARK_SIZE: usize = 1; // Size of the END option
+const OPTIONS_SIZE: usize = 335; // The maximum DHCP options field size used by this implementation
+const DHCP_PACKET_SIZE: usize = FIXED_PART_SIZE + OPTIONS_SIZE + END_OPTIONS_MARK_SIZE;
 
 /// Represents a DHCP lease entry for a client
 ///
@@ -873,7 +877,7 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     ///
     /// * `packet` - Mutable reference to the packet buffer
     /// * `msg_type` - DHCP message type to include in options
-    fn add_options(&self, packet: &mut Vec<u8, 576>, msg_type: u8) {
+    fn add_options(&self, packet: &mut Vec<u8, DHCP_PACKET_SIZE>, msg_type: u8) {
         packet
             .extend_from_slice(&[OPTION_MESSAGE_TYPE, 1, msg_type])
             .ok();
@@ -924,7 +928,7 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     /// # Returns
     ///
     /// A `Vec` containing the serialized DHCP response packet
-    fn make_response(&mut self, req: &DhcpPacket, msg_type: u8) -> Vec<u8, 576> {
+    fn make_response(&mut self, req: &DhcpPacket, msg_type: u8) -> Vec<u8, DHCP_PACKET_SIZE> {
         let mut resp = DhcpPacket {
             op: 2, // BOOTREPLY
             xid: req.xid,
@@ -957,7 +961,7 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
             }
             _ => {}
         }
-        let mut bytes = Vec::<u8, 576>::new();
+        let mut bytes = Vec::<u8, DHCP_PACKET_SIZE>::new();
         unsafe {
             let resp_bytes = core::slice::from_raw_parts(
                 (&raw const resp).cast::<u8>(),
@@ -1077,7 +1081,7 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
         socket: &mut DHCPServerSocket<'_>,
     ) -> Result<TransactionEvent, RecvError> {
         loop {
-            let mut buf = [0u8; 576];
+            let mut buf = [0u8; DHCP_PACKET_SIZE];
             match socket.socket.recv_from(&mut buf).await {
                 Ok((len, _)) => {
                     if let Some(event) = self.handle_packet(socket, &buf[..len]).await {
@@ -1142,7 +1146,7 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
         let mut buffers = DHCPServerBuffers::new();
         let socket = DHCPServerSocket::new(stack, &mut buffers);
         loop {
-            let mut buf = [0u8; 576];
+            let mut buf = [0u8; DHCP_PACKET_SIZE];
             match socket.socket.recv_from(&mut buf).await {
                 Ok((len, _)) => {
                     let _ = self.handle_packet(&socket, &buf[..len]).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@
 
 use core::net::Ipv4Addr;
 use embassy_net::Stack;
-use embassy_net::udp::{PacketMetadata, UdpSocket};
+use embassy_net::udp::{BindError, PacketMetadata, UdpSocket};
 use embassy_time::{Duration, Timer};
 use heapless::Vec;
 use smoltcp::phy::PacketMeta;
@@ -412,6 +412,79 @@ struct LeaseEntry {
     mac: [u8; 6],
     /// Timestamp when the lease expires (milliseconds since boot)
     lease_time: u64, // Timestamp when lease expires
+}
+
+/// Internal structure to hold UDP socket buffers and metadata
+/// for the DHCP server
+pub struct DHCPServerBuffers {
+    rx_buffer: [u8; DEFAULT_SOCKET_BUFFER_SIZE],
+    tx_buffer: [u8; DEFAULT_SOCKET_BUFFER_SIZE],
+    rx_meta: [PacketMetadata; 16],
+    tx_meta: [PacketMetadata; 16],
+}
+
+impl DHCPServerBuffers {
+    /// Creates a new set of DHCP server buffers with default sizes
+    /// # Returns
+    /// A new `DHCPServerBuffers` instance with pre-allocated buffers
+    /// # Examples
+    /// ```rust
+    /// use leasehund::DHCPServerBuffers;
+    /// let mut buffers = DHCPServerBuffers::new();
+    /// ```
+    ///
+    pub const fn new() -> Self {
+        Self {
+            rx_buffer: [0; DEFAULT_SOCKET_BUFFER_SIZE],
+            tx_buffer: [0; DEFAULT_SOCKET_BUFFER_SIZE],
+            rx_meta: [PacketMetadata::EMPTY; 16],
+            tx_meta: [PacketMetadata::EMPTY; 16],
+        }
+    }
+}
+
+/// Wrapper around the Embassy UDP socket for DHCP server use
+/// with associated buffers
+pub struct DHCPServerSocket<'a> {
+    socket: UdpSocket<'a>,
+}
+
+impl<'a> DHCPServerSocket<'a> {
+    /// Creates a new DHCP server UDP socket bound to the standard DHCP server port (67)
+    /// using the provided Embassy network stack and pre-allocated buffers.
+    /// The socket is configured to send responses to the DHCP client port (68).
+    /// # Arguments
+    /// * `stack` - The Embassy network stack to use for the socket
+    /// * `buffers` - Pre-allocated buffers for the UDP socket
+    /// # Returns
+    /// A new `DHCPServerSocket` instance
+    ///
+    /// # Examples
+    /// ```rust
+    /// use leasehund::{DHCPServerSocket, DHCPServerBuffers};
+    /// use embassy_net::Stack;
+    /// let stack: Stack = /* obtain Embassy network stack */;
+    /// let mut buffers = DHCPServerBuffers::new();
+    /// let socket = DHCPServerSocket::new(stack, &mut buffers);
+    /// ```
+    ///
+    pub fn new(stack: Stack<'a>, buffers: &'a mut DHCPServerBuffers) -> Self {
+        let socket = UdpSocket::new(
+            stack,
+            &mut buffers.rx_meta,
+            &mut buffers.rx_buffer,
+            &mut buffers.tx_meta,
+            &mut buffers.tx_buffer,
+        );
+        Self { socket }
+    }
+
+    /// Binds the UDP socket to the DHCP server port (67)
+    /// # Returns
+    /// `Ok(())` if binding was successful, or a `BindError` if it failed
+    fn bind(&mut self) -> Result<(), BindError> {
+        self.socket.bind(DHCP_SERVER_PORT)
+    }
 }
 
 /// A lightweight DHCP server implementation for embedded systems
@@ -870,7 +943,7 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     /// * `socket` - UDP socket for sending responses
     /// * `data` - Raw packet data received from client
     #[allow(clippy::future_not_send)]
-    async fn handle_packet(&mut self, socket: &UdpSocket<'_>, data: &[u8]) {
+    async fn handle_packet(&mut self, socket: &DHCPServerSocket<'_>, data: &[u8]) {
         if data.len() < core::mem::size_of::<DhcpPacket>() {
             return;
         }
@@ -888,7 +961,7 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
                         local_address: None,
                         meta: PacketMeta::default(),
                     };
-                    let _ = socket.send_to(&resp, meta).await;
+                    let _ = socket.socket.send_to(&resp, meta).await;
                 }
                 DHCP_REQUEST => {
                     let resp = self.make_response(packet, DHCP_ACK);
@@ -897,7 +970,7 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
                         local_address: None,
                         meta: PacketMeta::default(),
                     };
-                    let _ = socket.send_to(&resp, meta).await;
+                    let _ = socket.socket.send_to(&resp, meta).await;
                 }
                 DHCP_RELEASE => {
                     let mac: [u8; 6] = packet.chaddr[..6].try_into().unwrap_or([0; 6]);
@@ -955,21 +1028,13 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     /// ```
     #[allow(clippy::future_not_send)]
     pub async fn run(&mut self, stack: Stack<'_>) -> ! {
-        let mut rx_buffer = [0; DEFAULT_SOCKET_BUFFER_SIZE];
-        let mut tx_buffer = [0; DEFAULT_SOCKET_BUFFER_SIZE];
-        let mut rx_meta = [PacketMetadata::EMPTY; 16];
-        let mut tx_meta = [PacketMetadata::EMPTY; 16];
-        let mut socket = UdpSocket::new(
-            stack,
-            &mut rx_meta,
-            &mut rx_buffer,
-            &mut tx_meta,
-            &mut tx_buffer,
-        );
-        socket.bind(DHCP_SERVER_PORT).unwrap();
+        let mut buffers = DHCPServerBuffers::new();
+        let mut socket = DHCPServerSocket::new(stack, &mut buffers);
+        socket.bind().unwrap();
+
         loop {
             let mut buf = [0u8; 576];
-            match socket.recv_from(&mut buf).await {
+            match socket.socket.recv_from(&mut buf).await {
                 Ok((len, _)) => self.handle_packet(&socket, &buf[..len]).await,
                 Err(_) => Timer::after(Duration::from_millis(100)).await,
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -613,10 +613,7 @@ impl<'a> DHCPServerSocket<'a> {
 ///
 /// let server: DhcpServer<32, 4> = DhcpServer::with_config(config);
 /// ```
-pub struct DhcpServer<
-    const MAX_CLIENTS: usize = DEFAULT_MAX_CLIENTS,
-    const MAX_DNS: usize = DEFAULT_MAX_DNS_SERVERS,
-> {
+pub struct DhcpServer<const MAX_CLIENTS: usize = DEFAULT_MAX_CLIENTS, const MAX_DNS: usize = DEFAULT_MAX_DNS_SERVERS> {
     /// Server configuration
     config: DhcpConfig<MAX_DNS>,
     /// Hash map storing active leases, keyed by client MAC address


### PR DESCRIPTION
Add Single Lease Mode Support
Introduces manual DHCP transaction handling for enhanced control over the DHCP server process.

# ✨ Features Added

New lease_one() method - Handle individual DHCP transactions manually
DHCPServerBuffers struct - Dedicated buffer management for server operations
DHCPServerSocket wrapper - Simplified socket handling with proper lifetime management
TransactionEvent enum - Event-driven transaction results (Leased/Released)

# 📚 Improvements

Enhanced documentation with advanced usage examples
Eliminated magic constants for better code maintainability
Added comprehensive examples for an advanced use case

# 🔄 Compatibility

Fully backward compatible - existing run() method unchanged
Additive changes only - no breaking API modifications
Version bump: 0.2.0 → 0.3.0

# 💡 Use Cases

Custom logging of DHCP transactions
Event-driven DHCP handling
Integration with monitoring systems
Fine-grained control over lease management

This PR enables developers to choose between the existing simple run() method for basic use cases or the new 'lease_one()' method for applications requiring transaction-level control.