### PR TITLE
updated embassy-net from 0.7.0 -> 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["dhcp", "embedded", "no-std", "networking", "embassy"]
 readme = "README.md"
 
 [dependencies]
-embassy-net = { version = "0.7.0", features = [
+embassy-net = { version = "0.8.0", features = [
     "tcp",
     "udp",
     "dhcpv4",


### PR DESCRIPTION
the `embassy-net 0.7.0` was causing incompatibility issues with other crates.