### PR TITLE
v0.5.0: fix soundness, consolidate API, add lease expiry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ target
 
 /target
 Cargo.lock
+.agents

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-24
+
+### Breaking Changes
+- **Removed `new_with_dns`**: `DhcpServer::new()` now takes the DNS server parameter directly and uses it (previously the `new()` constructor silently ignored it). Use `new()` everywhere you used `new_with_dns()`.
+- **Removed `socket_buffer_size` from `DhcpConfig`**: This field was never used; UDP buffers are fixed at 1024 bytes.
+- **`DhcpConfigBuilder::new()` starts with no DNS servers**: Previously pre-populated with `8.8.8.8`. Add DNS servers explicitly with `.add_dns_server()`.
+- **`LeaseEntry.lease_time` renamed to `expires_at`**: Internal change, affects code that directly constructs `LeaseEntry` in tests.
+
+### Added
+- **Lease expiry enforcement**: Expired leases are automatically purged before each packet is processed. New public method `purge_expired_leases()`.
+- **IP reservation on OFFER**: Offered IPs are reserved with a 60-second TTL to prevent duplicate offers to concurrent clients.
+- Additional unit tests: `config_builder_starts_with_no_dns`, `config_builder_no_router`, `get_next_available_ip_empty`, `get_next_available_ip_skips_leased`, `parse_message_type_*`.
+
+### Fixed
+- **Unsound pointer cast**: Replaced `&*data.as_ptr().cast::<DhcpPacket>()` with `core::ptr::read_unaligned()` to avoid undefined behavior on unaligned UDP buffer data.
+- **Unsound serialization**: Replaced `core::slice::from_raw_parts` with `core::mem::transmute` to a byte array for safe packed struct serialization.
+- **Async bloat**: Consolidated duplicated `send_to().await` calls across DISCOVER/REQUEST match arms into a single suspend point, reducing the generated state machine size.
+
+### Removed
+- `DhcpServer::new_with_dns()` (use `new()` instead)
+- `DhcpConfig::socket_buffer_size` field
+- `DhcpConfigBuilder::socket_buffer_size()` method
+- `#[allow(dead_code)]` on `LeaseEntry`
+- `#[allow(clippy::unused_self)]` on static method `parse_message_type`
+
 ## [0.4.0] - 2026-03-27
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leasehund"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 authors = ["rttf <contact@rttf.dev>"]
 description = "A lightweight, embedded-friendly DHCP server implementation for Rust no_std environments"
@@ -12,7 +12,7 @@ keywords = ["dhcp", "embedded", "no-std", "networking", "embassy"]
 readme = "README.md"
 
 [dependencies]
-embassy-net = { version = "0.9.0", features = [
+embassy-net = { version = "0.9.1", features = [
     "tcp",
     "udp",
     "dhcpv4",
@@ -21,13 +21,13 @@ embassy-net = { version = "0.9.0", features = [
 ] }
 embassy-time = "0.5.1"
 hash32 = "0.3.1"
-heapless = "0.9.2"
-smoltcp = { version = "0.13.0", default-features = false, features = [
+heapless = "0.9.3"
+smoltcp = { version = "0.13.1", default-features = false, features = [
     "proto-ipv4",
     "proto-dhcpv4",
     "socket-udp",
 ] }
-defmt = { version = "1.0", optional = true }
+defmt = { version = "1.1", optional = true }
 
 [features]
 defmt = ["dep:defmt", "embassy-net/defmt"]

--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ Leasehund provides a minimal DHCP server implementation designed for embedded sy
 - **No-std compatible**: Designed for embedded systems without heap allocation
 - **Embassy integration**: Built on top of Embassy async runtime and networking stack
 - **Configurable IP pools**: Define custom IP address ranges for client assignment
-- **Lease management**: Automatic lease tracking with configurable timeouts
-- **Essential DHCP options**: Supports subnet mask, router, DNS server configuration
+- **Lease expiry**: Expired leases are automatically reclaimed before each allocation
+- **IP reservation**: Offered IPs are reserved to prevent duplicate offers
+- **Multiple DNS servers**: Support for up to N DNS servers (compile-time const generic)
+- **Optional router configuration**: Router/gateway can be disabled if not needed
+- **Builder pattern**: Fluent API for easy configuration
 - **Memory efficient**: Uses heapless data structures with compile-time size limits
-- **Safe**: Written in safe Rust with comprehensive error handling
 
 ## Quick Start
 
@@ -28,7 +30,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-leasehund = "0.4"
+leasehund = "0.5"
 ```
 
 ## Usage
@@ -46,8 +48,7 @@ async fn main(_spawner: Spawner) {
     // Initialize your embassy network stack here
     let stack = /* ... your network stack initialization ... */;
 
-    // Create DHCP server with explicit const generics
-    let mut dhcp_server: DhcpServer<32, 4> = DhcpServer::new_with_dns(
+    let mut server = DhcpServer::<32, 4>::new(
         Ipv4Addr::new(192, 168, 1, 1),    // Server IP
         Ipv4Addr::new(255, 255, 255, 0),  // Subnet mask
         Ipv4Addr::new(192, 168, 1, 1),    // Router/Gateway
@@ -57,7 +58,7 @@ async fn main(_spawner: Spawner) {
     );
 
     // Run the DHCP server (this will loop forever)
-    dhcp_server.run(stack).await;
+    server.run(stack).await;
 }
 ```
 
@@ -76,18 +77,15 @@ The DHCP server requires the following configuration parameters:
 | `ip_pool_start` | First IP in the assignable range | `192.168.1.100` |
 | `ip_pool_end`   | Last IP in the assignable range  | `192.168.1.200` |
 
-### Advanced Configuration
-
-
 ### Advanced Configuration (Builder Pattern)
 
-You can use the builder API to customize all key DHCP server parameters at runtime (const generics for sizing):
+Use the builder API for multiple DNS servers and custom options:
 
 ```rust
 use core::net::Ipv4Addr;
 use leasehund::{DhcpConfigBuilder, DhcpServer};
 
-let config: leasehund::DhcpConfig<4> = DhcpConfigBuilder::<4>::new()
+let config = DhcpConfigBuilder::<4>::new()
     .server_ip(Ipv4Addr::new(10, 0, 1, 1))
     .subnet_mask(Ipv4Addr::new(255, 255, 0, 0))
     .router(Ipv4Addr::new(10, 0, 1, 1))
@@ -95,13 +93,12 @@ let config: leasehund::DhcpConfig<4> = DhcpConfigBuilder::<4>::new()
     .add_dns_server(Ipv4Addr::new(1, 0, 0, 1))
     .ip_pool(Ipv4Addr::new(10, 0, 100, 1), Ipv4Addr::new(10, 0, 199, 254))
     .lease_time(7200) // 2 hours
-    .socket_buffer_size(2048)
     .build();
 
 let server: DhcpServer<32, 4> = DhcpServer::with_config(config);
 ```
 
-**Note:** The maximum number of concurrent leases and DNS servers are now compile-time constants set via const generics (e.g., `DhcpServer::<32, 4>`).
+**Note:** The builder starts with **no DNS servers**. Use `.add_dns_server()` to add them. The maximum number of concurrent leases and DNS servers are compile-time constants set via const generics (e.g., `DhcpServer::<32, 4>`).
 
 ## Supported DHCP Messages
 
@@ -122,42 +119,39 @@ The server automatically includes these standard DHCP options in responses:
 - **Option 53**: DHCP Message Type
 - **Option 54**: Server Identifier
 
-
-## Advanced uscase
+## Advanced Usage
 
 In case you need to handle lease/release events of each new client you can use the `lease_one` method:
 
 ```rust
 use core::net::Ipv4Addr;
-use leasehund::{DhcpServer, DHCPServerSocket, TransactionEvent};
+use leasehund::{DhcpServer, DhcpConfigBuilder, DHCPServerSocket, DHCPServerBuffers, TransactionEvent};
 use embassy_net::Stack;
-use core::net::Ipv4Addr;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     // Initialize your embassy network stack here
     let stack = /* ... your network stack initialization ... */;
-    
-    let config: DhcpConfig<4> = DhcpConfigBuilder::new()
+
+    let config = DhcpConfigBuilder::<4>::new()
         .server_ip(Ipv4Addr::new(10, 0, 1, 1))
         .subnet_mask(Ipv4Addr::new(255, 255, 0, 0))
         .router(Ipv4Addr::new(10, 0, 1, 1))
-        .add_dns_server(Ipv4Addr::new(1, 1, 1, 1))      // Cloudflare DNS
-        .add_dns_server(Ipv4Addr::new(1, 0, 0, 1))      // Cloudflare backup
-        .add_dns_server(Ipv4Addr::new(8, 8, 8, 8))      // Google DNS
+        .add_dns_server(Ipv4Addr::new(1, 1, 1, 1))
+        .add_dns_server(Ipv4Addr::new(1, 0, 0, 1))
+        .add_dns_server(Ipv4Addr::new(8, 8, 8, 8))
         .ip_pool(
             Ipv4Addr::new(10, 0, 100, 1),
             Ipv4Addr::new(10, 0, 199, 254)
         )
-        .lease_time(7200)    // 2 hours
+        .lease_time(7200)
         .build();
-    
-    let mut dhcp_server: DhcpServer<32, 4> = DhcpServer::with_config(config);
+
+    let mut server: DhcpServer<32, 4> = DhcpServer::with_config(config);
     let mut buffers = DHCPServerBuffers::new();
     let mut socket = DHCPServerSocket::new(stack, &mut buffers);
     loop {
-        let Ok(event) = server.lease_one(&socket).await else {
-            // Handle error (e.g., log it)
+        let Ok(event) = server.lease_one(&mut socket).await else {
             continue;
         };
 
@@ -183,7 +177,7 @@ Leasehund is compliant with [RFC 2131](https://www.rfc-editor.org/rfc/rfc2131) a
 
 The server uses fixed-size data structures to ensure predictable memory usage:
 
-- **Lease Storage**: `FnvIndexMap` with maximum number of entries set by the const generic parameter (e.g., `DhcpServer::<32, 4>`, compile-time fixed)
+- **Lease Storage**: `FnvIndexMap` with maximum entries set by const generic (e.g., `DhcpServer::<32, 4>`)
 - **Packet Buffers**: 1KB RX/TX buffers for UDP socket
 - **Response Packets**: Maximum 576 bytes per DHCP response
 
@@ -199,7 +193,7 @@ The server uses fixed-size data structures to ensure predictable memory usage:
 ### Simple Home Network
 
 ```rust
-let dhcp_server: DhcpServer<32, 4> = DhcpServer::new_with_dns(
+let server = DhcpServer::<32, 4>::new(
     Ipv4Addr::new(192, 168, 1, 1),    // Router IP
     Ipv4Addr::new(255, 255, 255, 0),  // /24 network
     Ipv4Addr::new(192, 168, 1, 1),    // Gateway
@@ -212,7 +206,7 @@ let dhcp_server: DhcpServer<32, 4> = DhcpServer::new_with_dns(
 ### Corporate Network
 
 ```rust
-let dhcp_server: DhcpServer<32, 4> = DhcpServer::new_with_dns(
+let server = DhcpServer::<32, 4>::new(
     Ipv4Addr::new(10, 0, 1, 1),       // Server IP
     Ipv4Addr::new(255, 255, 0, 0),    // /16 network
     Ipv4Addr::new(10, 0, 1, 1),       // Gateway
@@ -226,10 +220,9 @@ let dhcp_server: DhcpServer<32, 4> = DhcpServer::new_with_dns(
 
 - **IPv4 Only**: IPv6 is not supported
 - **Lease Time**: Configurable at runtime via `DhcpConfig`/`DhcpConfigBuilder` (default 24 hours)
-- **Sizing**: Maximum clients and DNS servers are compile-time constants set via const generics (e.g., `DhcpServer::<32, 4>`)
+- **Sizing**: Maximum clients and DNS servers are compile-time constants set via const generics
 - **Basic Options**: Limited to essential DHCP options
 - **No Relay**: DHCP relay functionality not implemented
-- **Client Limit**: Maximum of 32 concurrent clients (compile-time fixed, set via const generics, e.g., `DhcpServer::<32, 4>`)
 
 ## Requirements
 
@@ -247,8 +240,7 @@ Contributions are welcome! Please feel free to submit a Pull Request. For major 
 ```bash
 git clone https://github.com/rttfd/leasehund.git
 cd leasehund
-cargo build
-cargo test
+make ci
 ```
 
 ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,9 @@
 //! - **No-std compatible**: Designed for embedded systems without heap allocation
 //! - **Embassy integration**: Built on top of Embassy async runtime and networking stack
 //! - **Configurable IP pools**: Define custom IP address ranges for client assignment
-//! - **Flexible lease management**: Configurable lease times and automatic tracking
-//! - **Multiple DNS servers**: Support for up to 4 DNS servers
+//! - **Lease expiry**: Expired leases are automatically reclaimed before each allocation
+//! - **IP reservation**: Offered IPs are reserved to prevent duplicate offers
+//! - **Multiple DNS servers**: Support for up to N DNS servers (compile-time const generic)
 //! - **Optional router configuration**: Router/gateway can be disabled if not needed
 //! - **Builder pattern**: Fluent API for easy configuration
 //! - **Memory efficient**: Uses heapless data structures with compile-time size limits
@@ -32,10 +33,9 @@
 //! use core::net::Ipv4Addr;
 //! use leasehund::DhcpServer;
 //! use embassy_net::Stack;
-//! use leasehund::DhcpConfig;
 //!
 //! # async fn example(stack: Stack<'static>) {
-//! let mut dhcp_server: DhcpServer<32, 4> = DhcpServer::new_with_dns(
+//! let mut server = DhcpServer::<32, 4>::new(
 //!     Ipv4Addr::new(192, 168, 1, 1),    // Server IP
 //!     Ipv4Addr::new(255, 255, 255, 0),  // Subnet mask
 //!     Ipv4Addr::new(192, 168, 1, 1),    // Router/Gateway
@@ -45,7 +45,7 @@
 //! );
 //!
 //! // Run the DHCP server (this will loop forever)
-//! dhcp_server.run(stack).await;
+//! server.run(stack).await;
 //! # }
 //! ```
 //!
@@ -55,25 +55,24 @@
 //! use core::net::Ipv4Addr;
 //! use leasehund::{DhcpServer, DhcpConfigBuilder};
 //! use embassy_net::Stack;
-//! use leasehund::DhcpConfig;
 //!
 //! # async fn example(stack: Stack<'static>) {
-//! let config: DhcpConfig<4> = DhcpConfigBuilder::new()
+//! let config = DhcpConfigBuilder::<4>::new()
 //!     .server_ip(Ipv4Addr::new(10, 0, 1, 1))
 //!     .subnet_mask(Ipv4Addr::new(255, 255, 0, 0))
 //!     .router(Ipv4Addr::new(10, 0, 1, 1))
-//!     .add_dns_server(Ipv4Addr::new(1, 1, 1, 1))      // Cloudflare DNS
-//!     .add_dns_server(Ipv4Addr::new(1, 0, 0, 1))      // Cloudflare backup
-//!     .add_dns_server(Ipv4Addr::new(8, 8, 8, 8))      // Google DNS
+//!     .add_dns_server(Ipv4Addr::new(1, 1, 1, 1))
+//!     .add_dns_server(Ipv4Addr::new(1, 0, 0, 1))
+//!     .add_dns_server(Ipv4Addr::new(8, 8, 8, 8))
 //!     .ip_pool(
 //!         Ipv4Addr::new(10, 0, 100, 1),
 //!         Ipv4Addr::new(10, 0, 199, 254)
 //!     )
-//!     .lease_time(7200)    // 2 hours
+//!     .lease_time(7200)
 //!     .build();
 //!
-//! let mut dhcp_server: DhcpServer<32, 4> = DhcpServer::with_config(config);
-//! dhcp_server.run(stack).await;
+//! let mut server: DhcpServer<32, 4> = DhcpServer::with_config(config);
+//! server.run(stack).await;
 //! # }
 //! ```
 //!
@@ -87,12 +86,9 @@
 //!
 //! ## Limitations
 //!
-//! - Maximum number of concurrent client leases is compile-time fixed via const generics (e.g., `DhcpServer::<32, 4>`, see examples)
-//! - Lease time, buffer size, and DNS servers are configurable at runtime via [`DhcpConfig`] / [`DhcpConfigBuilder`]
-//! - Support for multiple DNS servers (up to 4, set via const generics, e.g., `DhcpConfig::<4>`, see examples)
-//! - Optional router/gateway configuration
+//! - Maximum number of concurrent client leases is compile-time fixed via const generics
 //! - IPv4 only
-//! - Fixed UDP buffer sizes (1024 bytes by default, configurable)
+//! - Fixed UDP buffer sizes (1024 bytes)
 //!
 //! ## Network Configuration
 //!
@@ -103,24 +99,21 @@
 //! ## Memory Usage
 //!
 //! The server uses a fixed-size hash map to store lease information, with a maximum
-//! number of entries set by the `MAX_CLIENTS` const generic parameter (e.g., `DhcpServer::<32, 4>`). Each lease entry contains:
+//! number of entries set by the `MAX_CLIENTS` const generic parameter. Each lease entry contains:
 //! - IPv4 address (4 bytes)
-//! - MAC address (6 bytes)  
+//! - MAC address (6 bytes)
 //! - Lease expiration timestamp (8 bytes)
 //!
 //! ## Advanced Usage
 //!
-//! For the case you want to handle each transaction manually, you can use the `lease_one` method.
-//! This allows you to handle each DHCP transaction individually, giving you more control over the process.
-//! For instance, you might want to log each transaction or implement custom logic based on the transaction type.
-//! Here's an example of how to use `lease_one`:
+//! For manual transaction handling, use the `lease_one` method:
 //! ```rust
 //! use core::net::Ipv4Addr;
 //! use leasehund::{DhcpServer, DHCPServerSocket, DHCPServerBuffers, TransactionEvent, DhcpConfigBuilder};
 //! # use embassy_net::Stack;
 //!
 //! # async fn example(stack: Stack<'static>) {
-//! let config = DhcpConfigBuilder::new()
+//! let config = DhcpConfigBuilder::<4>::new()
 //!     .server_ip(Ipv4Addr::new(10, 0, 1, 1))
 //!     .subnet_mask(Ipv4Addr::new(255, 255, 0, 0))
 //!     .router(Ipv4Addr::new(10, 0, 1, 1))
@@ -133,13 +126,12 @@
 //!     )
 //!     .lease_time(7200)
 //!     .build();
-//! let mut dhcp_server = DhcpServer::<32, 4>::with_config(config);
+//! let mut server = DhcpServer::<32, 4>::with_config(config);
 //! let mut buffers = DHCPServerBuffers::new();
 //! let mut socket = DHCPServerSocket::new(stack, &mut buffers);
-//! let _event: Result<TransactionEvent, _> = dhcp_server.lease_one(&mut socket).await;
+//! let _event: Result<TransactionEvent, _> = server.lease_one(&mut socket).await;
 //! # }
 //! ```
-//!
 
 #![no_std]
 #![warn(missing_docs)]
@@ -163,27 +155,26 @@ const DHCP_SERVER_PORT: u16 = 67;
 /// Standard DHCP client port (RFC 2131)
 const DHCP_CLIENT_PORT: u16 = 68;
 
-// Default values for DHCP server configuration (used for compile-time sizing)
+// Default values for DHCP server configuration
 const DEFAULT_MAX_CLIENTS: usize = 32;
 const DEFAULT_MAX_DNS_SERVERS: usize = 4;
 const DEFAULT_LEASE_TIME: u32 = 86400; // 24 hours in seconds
-const DEFAULT_SOCKET_BUFFER_SIZE: usize = 1024;
+const SOCKET_BUFFER_SIZE: usize = 1024;
 
-/// Configuration options for the DHCP server
-///
-/// This structure allows customization of various DHCP server parameters
-/// including lease time, buffer sizes, and optional settings.
+/// Duration in milliseconds to reserve an offered IP before the client confirms.
+const OFFER_RESERVATION_MS: u64 = 60_000;
+
+/// Configuration options for the DHCP server.
 ///
 /// # Examples
 ///
 /// ```rust
 /// use core::net::Ipv4Addr;
 /// use leasehund::{DhcpConfig, DhcpServer};
-/// use heapless::Vec;
 ///
-/// let mut dns_servers = heapless::Vec::<core::net::Ipv4Addr, 4>::new();
-/// dns_servers.push(core::net::Ipv4Addr::new(8, 8, 8, 8)).ok();
-/// dns_servers.push(core::net::Ipv4Addr::new(8, 8, 4, 4)).ok();
+/// let mut dns_servers = heapless::Vec::<Ipv4Addr, 4>::new();
+/// dns_servers.push(Ipv4Addr::new(8, 8, 8, 8)).ok();
+/// dns_servers.push(Ipv4Addr::new(8, 8, 4, 4)).ok();
 ///
 /// let config: DhcpConfig<4> = DhcpConfig {
 ///     server_ip: Ipv4Addr::new(192, 168, 1, 1),
@@ -192,8 +183,7 @@ const DEFAULT_SOCKET_BUFFER_SIZE: usize = 1024;
 ///     dns_servers,
 ///     ip_pool_start: Ipv4Addr::new(192, 168, 1, 100),
 ///     ip_pool_end: Ipv4Addr::new(192, 168, 1, 200),
-///     lease_time: 3600, // 1 hour
-///     socket_buffer_size: 1024,
+///     lease_time: 3600,
 /// };
 ///
 /// let server: DhcpServer<32, 4> = DhcpServer::with_config(config);
@@ -214,14 +204,12 @@ pub struct DhcpConfig<const MAX_DNS: usize = DEFAULT_MAX_DNS_SERVERS> {
     pub ip_pool_end: Ipv4Addr,
     /// Lease time in seconds (default: 24 hours)
     pub lease_time: u32,
-    /// UDP socket buffer size in bytes (default: 1024)
-    pub socket_buffer_size: usize,
 }
 
 impl<const MAX_DNS: usize> Default for DhcpConfig<MAX_DNS> {
     fn default() -> Self {
         let mut dns_servers = heapless::Vec::new();
-        let _ = dns_servers.push(Ipv4Addr::new(8, 8, 8, 8)); // Google DNS
+        let _ = dns_servers.push(Ipv4Addr::new(8, 8, 8, 8));
         Self {
             server_ip: Ipv4Addr::new(192, 168, 1, 1),
             subnet_mask: Ipv4Addr::new(255, 255, 255, 0),
@@ -230,14 +218,14 @@ impl<const MAX_DNS: usize> Default for DhcpConfig<MAX_DNS> {
             ip_pool_start: Ipv4Addr::new(192, 168, 1, 100),
             ip_pool_end: Ipv4Addr::new(192, 168, 1, 200),
             lease_time: DEFAULT_LEASE_TIME,
-            socket_buffer_size: DEFAULT_SOCKET_BUFFER_SIZE,
         }
     }
 }
 
-/// Builder pattern for creating DHCP server configurations
+/// Builder pattern for creating DHCP server configurations.
 ///
-/// Provides a fluent interface for configuring DHCP server options.
+/// The builder starts with **no DNS servers** configured. Use
+/// [`add_dns_server`](Self::add_dns_server) to add them.
 ///
 /// # Examples
 ///
@@ -245,7 +233,7 @@ impl<const MAX_DNS: usize> Default for DhcpConfig<MAX_DNS> {
 /// use core::net::Ipv4Addr;
 /// use leasehund::{DhcpConfigBuilder, DhcpServer};
 ///
-/// let config: leasehund::DhcpConfig<4> = DhcpConfigBuilder::<4>::new()
+/// let config = DhcpConfigBuilder::<4>::new()
 ///     .server_ip(Ipv4Addr::new(10, 0, 1, 1))
 ///     .subnet_mask(Ipv4Addr::new(255, 255, 0, 0))
 ///     .router(Ipv4Addr::new(10, 0, 1, 1))
@@ -255,7 +243,7 @@ impl<const MAX_DNS: usize> Default for DhcpConfig<MAX_DNS> {
 ///         Ipv4Addr::new(10, 0, 100, 1),
 ///         Ipv4Addr::new(10, 0, 199, 254)
 ///     )
-///     .lease_time(7200) // 2 hours
+///     .lease_time(7200)
 ///     .build();
 ///
 /// let server: DhcpServer<32, 4> = DhcpServer::with_config(config);
@@ -266,57 +254,62 @@ pub struct DhcpConfigBuilder<const MAX_DNS: usize = DEFAULT_MAX_DNS_SERVERS> {
 }
 
 impl<const MAX_DNS: usize> DhcpConfigBuilder<MAX_DNS> {
-    /// Creates a new configuration builder with default values
+    /// Creates a new configuration builder.
+    ///
+    /// Starts with sensible defaults but **no DNS servers**.
     #[must_use]
     pub fn new() -> Self {
-        Self {
-            config: DhcpConfig::default(),
-        }
+        let mut config = DhcpConfig::default();
+        config.dns_servers.clear();
+        Self { config }
     }
 
-    /// Sets the DHCP server IP address
+    /// Sets the DHCP server IP address.
     #[must_use]
     pub const fn server_ip(mut self, ip: Ipv4Addr) -> Self {
         self.config.server_ip = ip;
         self
     }
 
-    /// Sets the subnet mask
+    /// Sets the subnet mask.
     #[must_use]
     pub const fn subnet_mask(mut self, mask: Ipv4Addr) -> Self {
         self.config.subnet_mask = mask;
         self
     }
 
-    /// Sets the default gateway/router IP address
+    /// Sets the default gateway/router IP address.
     #[must_use]
     pub const fn router(mut self, router: Ipv4Addr) -> Self {
         self.config.router = Some(router);
         self
     }
 
-    /// Removes the router option (no default gateway)
+    /// Removes the router option (no default gateway).
     #[must_use]
     pub const fn no_router(mut self) -> Self {
         self.config.router = None;
         self
     }
 
-    /// Adds a DNS server to the configuration
+    /// Adds a DNS server to the configuration.
+    ///
+    /// If the maximum number of DNS servers has been reached, the server
+    /// is silently dropped.
     #[must_use]
     pub fn add_dns_server(mut self, dns: Ipv4Addr) -> Self {
         let _ = self.config.dns_servers.push(dns);
         self
     }
 
-    /// Clears all DNS servers
+    /// Clears all DNS servers.
     #[must_use]
     pub fn clear_dns_servers(mut self) -> Self {
         self.config.dns_servers.clear();
         self
     }
 
-    /// Sets the IP address pool range
+    /// Sets the IP address pool range.
     #[must_use]
     pub const fn ip_pool(mut self, start: Ipv4Addr, end: Ipv4Addr) -> Self {
         self.config.ip_pool_start = start;
@@ -324,21 +317,14 @@ impl<const MAX_DNS: usize> DhcpConfigBuilder<MAX_DNS> {
         self
     }
 
-    /// Sets the lease time in seconds
+    /// Sets the lease time in seconds.
     #[must_use]
     pub const fn lease_time(mut self, seconds: u32) -> Self {
         self.config.lease_time = seconds;
         self
     }
 
-    /// Sets the UDP socket buffer size
-    #[must_use]
-    pub const fn socket_buffer_size(mut self, size: usize) -> Self {
-        self.config.socket_buffer_size = size;
-        self
-    }
-
-    /// Builds the final configuration
+    /// Builds the final configuration.
     #[must_use]
     pub fn build(self) -> DhcpConfig<MAX_DNS> {
         self.config
@@ -352,7 +338,6 @@ impl<const MAX_DNS: usize> Default for DhcpConfigBuilder<MAX_DNS> {
 }
 
 // DHCP Message Types (RFC 2131)
-// Internal DHCP message type codes (RFC 2131)
 const DHCP_DISCOVER: u8 = 1;
 const DHCP_OFFER: u8 = 2;
 const DHCP_REQUEST: u8 = 3;
@@ -360,7 +345,6 @@ const DHCP_ACK: u8 = 5;
 const DHCP_RELEASE: u8 = 7;
 
 // DHCP Options (RFC 2132)
-// Internal DHCP option codes (RFC 2132)
 const OPTION_SUBNET_MASK: u8 = 1;
 const OPTION_ROUTER: u8 = 3;
 const OPTION_DNS_SERVER: u8 = 6;
@@ -370,47 +354,29 @@ const OPTION_SERVER_ID: u8 = 54;
 const OPTION_END: u8 = 255;
 
 // The standard DHCP magic cookie (0x63825363).
-// This value is required by RFC 2132 section 2 (see <https://www.rfc-editor.org/rfc/rfc2132#section-2>),
-// and is used to identify DHCP packets and options. All incoming packets are checked for this value.
+// Required by RFC 2132 section 2.
 const DHCP_MAGIC: [u8; 4] = [0x63, 0x82, 0x53, 0x63];
 
-/// DHCP packet structure as defined in [RFC 2131](https://www.rfc-editor.org/rfc/rfc2131)
+/// DHCP packet structure as defined in [RFC 2131](https://www.rfc-editor.org/rfc/rfc2131).
 ///
-/// This represents the fixed portion of a DHCP message, followed by
-/// variable-length options. The structure is packed to ensure correct
-/// wire format representation. The `magic` field is always set to the standard DHCP magic cookie (0x63825363).
+/// Packed to match the wire format exactly.
 #[repr(C, packed)]
 #[derive(Clone, Copy)]
 struct DhcpPacket {
-    /// Message operation code: 1 = BOOTREQUEST, 2 = BOOTREPLY
     op: u8,
-    /// Hardware address type (1 = Ethernet)
     htype: u8,
-    /// Hardware address length (6 for Ethernet)
     hlen: u8,
-    /// Number of relay agent hops
     hops: u8,
-    /// Transaction ID, chosen by client
     xid: u32,
-    /// Seconds elapsed since client began address acquisition
     secs: u16,
-    /// Flags (bit 0 = broadcast flag)
     flags: u16,
-    /// Client IP address (if client is in BOUND, RENEW or REBINDING state)
     ciaddr: [u8; 4],
-    /// 'Your' (client) IP address
     yiaddr: [u8; 4],
-    /// IP address of next server to use in bootstrap
     siaddr: [u8; 4],
-    /// Relay agent IP address
     giaddr: [u8; 4],
-    /// Client hardware address (16 bytes, only first 6 used for Ethernet)
     chaddr: [u8; 16],
-    /// Optional server host name (null terminated string)
     sname: [u8; 64],
-    /// Boot file name (null terminated string)
     file: [u8; 128],
-    /// DHCP magic cookie (see [`DHCP_MAGIC`])
     magic: [u8; 4],
 }
 
@@ -431,59 +397,46 @@ impl Default for DhcpPacket {
             chaddr: [0; 16],
             sname: [0; 64],
             file: [0; 128],
-            magic: DHCP_MAGIC, // Always set to the standard DHCP magic cookie
+            magic: DHCP_MAGIC,
         }
     }
 }
-/// The total size of a fixed part the DHCP packet
-const FIXED_PART_SIZE: usize = core::mem::size_of::<DhcpPacket>();
-/// Size of the END option (1 byte)
-const END_OPTIONS_MARK_SIZE: usize = 1; // Size of the END option
-/// The maximum DHCP options field size used by this implementation
-const OPTIONS_SIZE: usize = 335;
-/// Total DHCP packet size (fixed part + options + END option)
-const DHCP_PACKET_SIZE: usize = FIXED_PART_SIZE + OPTIONS_SIZE + END_OPTIONS_MARK_SIZE;
 
-/// Represents a DHCP lease entry for a client
-///
-/// Contains the assigned IP address, client MAC address, and lease expiration time.
-/// Used internally by the DHCP server to track active leases.
-#[allow(dead_code)]
+const FIXED_PART_SIZE: usize = core::mem::size_of::<DhcpPacket>();
+const OPTIONS_SIZE: usize = 335;
+const DHCP_PACKET_SIZE: usize = FIXED_PART_SIZE + OPTIONS_SIZE + 1; // +1 for END option
+
+/// A DHCP lease entry for a client.
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct LeaseEntry {
-    /// The IP address assigned to the client
     ip: Ipv4Addr,
-    /// The MAC address of the client (6 bytes for Ethernet)
     mac: [u8; 6],
-    /// Timestamp when the lease expires (milliseconds since boot)
-    lease_time: u64, // Timestamp when lease expires
+    expires_at: u64,
 }
 
-/// Internal structure to hold UDP socket buffers and metadata
-/// for the DHCP server
+/// Pre-allocated UDP socket buffers and metadata for the DHCP server.
 pub struct DHCPServerBuffers {
-    rx_buffer: [u8; DEFAULT_SOCKET_BUFFER_SIZE],
-    tx_buffer: [u8; DEFAULT_SOCKET_BUFFER_SIZE],
+    rx_buffer: [u8; SOCKET_BUFFER_SIZE],
+    tx_buffer: [u8; SOCKET_BUFFER_SIZE],
     rx_meta: [PacketMetadata; 16],
     tx_meta: [PacketMetadata; 16],
 }
 
 impl DHCPServerBuffers {
-    /// Creates a new set of DHCP server buffers with default sizes
-    /// # Returns
-    /// A new `DHCPServerBuffers` instance with pre-allocated buffers
+    /// Creates a new set of DHCP server buffers.
+    ///
     /// # Examples
+    ///
     /// ```rust
     /// use leasehund::DHCPServerBuffers;
-    /// let mut buffers = DHCPServerBuffers::new();
+    /// let buffers = DHCPServerBuffers::new();
     /// ```
-    ///
     #[must_use]
     pub const fn new() -> Self {
         Self {
-            rx_buffer: [0; DEFAULT_SOCKET_BUFFER_SIZE],
-            tx_buffer: [0; DEFAULT_SOCKET_BUFFER_SIZE],
+            rx_buffer: [0; SOCKET_BUFFER_SIZE],
+            tx_buffer: [0; SOCKET_BUFFER_SIZE],
             rx_meta: [PacketMetadata::EMPTY; 16],
             tx_meta: [PacketMetadata::EMPTY; 16],
         }
@@ -496,55 +449,46 @@ impl Default for DHCPServerBuffers {
     }
 }
 
-/// Represents a DHCP lease/release event
-/// Used for logging and monitoring lease assignments and releases
+/// Represents a DHCP lease or release event.
 ///
-/// - **Leased** - indicates a new lease assignment
-///
-/// - **Released** - indicates a release the IP by a client
-///   Each event includes the relevant IP address and client MAC address
 /// # Examples
+///
 /// ```rust
 /// use leasehund::TransactionEvent;
 /// use core::net::Ipv4Addr;
-/// let event = TransactionEvent::Leased(Ipv4Addr::new(192, 168, 1, 100), [0x00, 0x11, 0x22, 0x33, 0x44, 0x55]);    
+/// let event = TransactionEvent::Leased(Ipv4Addr::new(192, 168, 1, 100), [0x00, 0x11, 0x22, 0x33, 0x44, 0x55]);
 /// ```
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TransactionEvent {
-    /// Indicates a new lease assignment
+    /// A new lease was assigned.
     Leased(Ipv4Addr, [u8; 6]),
-    /// Indicates a release the IP by a client
+    /// A client released its IP.
     Released(Ipv4Addr, [u8; 6]),
 }
 
 /// Wrapper around the Embassy UDP socket for DHCP server use.
 pub struct DHCPServerSocket<'a> {
-    /// The underlying Embassy UDP socket
     socket: UdpSocket<'a>,
 }
 
 impl<'a> DHCPServerSocket<'a> {
-    /// Creates a new DHCP server UDP socket bound to the standard DHCP server port (67)
-    /// using the provided Embassy network stack and pre-allocated buffers.
-    /// # Arguments
-    /// * `stack` - The Embassy network stack to use for the socket
-    /// * `buffers` - Pre-allocated buffers for the UDP socket
-    /// # Returns
-    /// A new `DHCPServerSocket` instance
+    /// Creates a new DHCP server UDP socket bound to port 67.
+    ///
     /// # Panics
-    /// This function will panic if the socket binding fails.
+    ///
+    /// Panics if the socket binding fails.
     ///
     /// # Examples
+    ///
     /// ```rust
     /// use leasehund::{DHCPServerSocket, DHCPServerBuffers};
     /// # use embassy_net::Stack;
     /// # fn example(stack: Stack<'static>) {
     /// let mut buffers = DHCPServerBuffers::new();
-    /// let mut socket = DHCPServerSocket::new(stack, &mut buffers);
+    /// let socket = DHCPServerSocket::new(stack, &mut buffers);
     /// # }
     /// ```
-    ///
     #[must_use]
     pub fn new(stack: Stack<'a>, buffers: &'a mut DHCPServerBuffers) -> Self {
         let mut socket = UdpSocket::new(
@@ -559,44 +503,41 @@ impl<'a> DHCPServerSocket<'a> {
     }
 }
 
-/// A lightweight DHCP server implementation for embedded systems
+/// A lightweight DHCP server implementation for embedded systems.
 ///
-/// This server provides basic DHCP functionality including IP address assignment,
-/// lease management, and essential DHCP options. It's designed to work in `no_std`
-/// environments with minimal memory usage.
+/// # Type Parameters
+///
+/// - `MAX_CLIENTS`: Maximum number of concurrent leases (compile-time fixed)
+/// - `MAX_DNS`: Maximum number of DNS servers in configuration
 ///
 /// # Examples
-///
-/// ## Basic usage with simple constructor
 ///
 /// ```rust,no_run
 /// use core::net::Ipv4Addr;
 /// use leasehund::DhcpServer;
 ///
-/// let server: DhcpServer<32, 4> = DhcpServer::new(
-///     Ipv4Addr::new(192, 168, 1, 1),    // Server IP
-///     Ipv4Addr::new(255, 255, 255, 0),  // Subnet mask  
-///     Ipv4Addr::new(192, 168, 1, 1),    // Gateway
-///     Ipv4Addr::new(8, 8, 8, 8),        // DNS server
-///     Ipv4Addr::new(192, 168, 1, 100),  // Pool start
-///     Ipv4Addr::new(192, 168, 1, 200),  // Pool end
+/// let server = DhcpServer::<32, 4>::new(
+///     Ipv4Addr::new(192, 168, 1, 1),
+///     Ipv4Addr::new(255, 255, 255, 0),
+///     Ipv4Addr::new(192, 168, 1, 1),
+///     Ipv4Addr::new(8, 8, 8, 8),
+///     Ipv4Addr::new(192, 168, 1, 100),
+///     Ipv4Addr::new(192, 168, 1, 200),
 /// );
 /// ```
-///
-/// ## Advanced usage with configuration builder
 ///
 /// ```rust,no_run
 /// use core::net::Ipv4Addr;
 /// use leasehund::{DhcpServer, DhcpConfigBuilder};
 ///
-/// let config: leasehund::DhcpConfig<4> = DhcpConfigBuilder::<4>::new()
+/// let config = DhcpConfigBuilder::<4>::new()
 ///     .server_ip(Ipv4Addr::new(10, 0, 1, 1))
 ///     .subnet_mask(Ipv4Addr::new(255, 255, 0, 0))
 ///     .router(Ipv4Addr::new(10, 0, 1, 1))
 ///     .add_dns_server(Ipv4Addr::new(1, 1, 1, 1))
 ///     .add_dns_server(Ipv4Addr::new(1, 0, 0, 1))
 ///     .ip_pool(Ipv4Addr::new(10, 0, 100, 1), Ipv4Addr::new(10, 0, 199, 254))
-///     .lease_time(7200) // 2 hours
+///     .lease_time(7200)
 ///     .build();
 ///
 /// let server: DhcpServer<32, 4> = DhcpServer::with_config(config);
@@ -605,27 +546,15 @@ pub struct DhcpServer<
     const MAX_CLIENTS: usize = DEFAULT_MAX_CLIENTS,
     const MAX_DNS: usize = DEFAULT_MAX_DNS_SERVERS,
 > {
-    /// Server configuration
     config: DhcpConfig<MAX_DNS>,
-    /// Hash map storing active leases, keyed by client MAC address
     leases: IndexMap<[u8; 6], LeaseEntry, BuildHasherDefault<FnvHasher>, MAX_CLIENTS>,
 }
 
 impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX_DNS> {
-    /// Creates a new DHCP server with the specified configuration
+    /// Creates a new DHCP server with a single DNS server.
     ///
-    /// # Arguments
-    ///
-    /// * `server_ip` - The IP address of this DHCP server
-    /// * `subnet_mask` - Subnet mask to assign to clients (e.g., 255.255.255.0)
-    /// * `router` - Default gateway IP address to assign to clients
-    /// * `dns_server` - DNS server IP address to assign to clients
-    /// * `ip_pool_start` - First IP address in the pool for client assignment
-    /// * `ip_pool_end` - Last IP address in the pool for client assignment
-    ///
-    /// # Returns
-    ///
-    /// A new `DhcpServer` instance ready to handle DHCP requests
+    /// For multiple DNS servers or advanced options, use
+    /// [`DhcpConfigBuilder`] with [`with_config`](Self::with_config).
     ///
     /// # Examples
     ///
@@ -633,76 +562,17 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     /// use core::net::Ipv4Addr;
     /// use leasehund::DhcpServer;
     ///
-    /// let server: DhcpServer<32, 4> = DhcpServer::new(
-    ///     Ipv4Addr::new(192, 168, 1, 1),    // Server IP
-    ///     Ipv4Addr::new(255, 255, 255, 0),  // Subnet mask
-    ///     Ipv4Addr::new(192, 168, 1, 1),    // Gateway
-    ///     Ipv4Addr::new(8, 8, 8, 8),        // DNS
-    ///     Ipv4Addr::new(192, 168, 1, 100),  // Pool start
-    ///     Ipv4Addr::new(192, 168, 1, 200),  // Pool end
-    /// );
-    /// ```
-    ///
-    #[must_use]
-    pub const fn new(
-        server_ip: Ipv4Addr,
-        subnet_mask: Ipv4Addr,
-        router: Ipv4Addr,
-        _dns_server: Ipv4Addr, // Unused in const context, but kept for API compatibility
-        ip_pool_start: Ipv4Addr,
-        ip_pool_end: Ipv4Addr,
-    ) -> Self {
-        let config = DhcpConfig::<MAX_DNS> {
-            server_ip,
-            subnet_mask,
-            router: Some(router),
-            dns_servers: heapless::Vec::new(),
-            ip_pool_start,
-            ip_pool_end,
-            lease_time: DEFAULT_LEASE_TIME,
-            socket_buffer_size: DEFAULT_SOCKET_BUFFER_SIZE,
-        };
-        Self {
-            config,
-            leases: IndexMap::new(),
-        }
-    }
-
-    /// Creates a new DHCP server with simple configuration and a single DNS server
-    ///
-    /// This is a non-const version of `new` that properly handles the DNS server.
-    /// Use this when you need the DNS server to be included in the configuration.
-    ///
-    /// # Arguments
-    ///
-    /// * `server_ip` - The IP address of this DHCP server
-    /// * `subnet_mask` - Subnet mask to assign to clients (e.g., 255.255.255.0)
-    /// * `router` - Default gateway IP address to assign to clients
-    /// * `dns_server` - DNS server IP address to assign to clients
-    /// * `ip_pool_start` - First IP address in the pool for client assignment
-    /// * `ip_pool_end` - Last IP address in the pool for client assignment
-    ///
-    /// # Returns
-    ///
-    /// A new `DhcpServer` instance ready to handle DHCP requests
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use core::net::Ipv4Addr;
-    /// use leasehund::DhcpServer;
-    ///
-    /// let server = DhcpServer::<32, 4>::new_with_dns(
-    ///     Ipv4Addr::new(192, 168, 1, 1),    // Server IP
-    ///     Ipv4Addr::new(255, 255, 255, 0),  // Subnet mask
-    ///     Ipv4Addr::new(192, 168, 1, 1),    // Gateway
-    ///     Ipv4Addr::new(8, 8, 8, 8),        // DNS
-    ///     Ipv4Addr::new(192, 168, 1, 100),  // Pool start
-    ///     Ipv4Addr::new(192, 168, 1, 200),  // Pool end
+    /// let server = DhcpServer::<32, 4>::new(
+    ///     Ipv4Addr::new(192, 168, 1, 1),
+    ///     Ipv4Addr::new(255, 255, 255, 0),
+    ///     Ipv4Addr::new(192, 168, 1, 1),
+    ///     Ipv4Addr::new(8, 8, 8, 8),
+    ///     Ipv4Addr::new(192, 168, 1, 100),
+    ///     Ipv4Addr::new(192, 168, 1, 200),
     /// );
     /// ```
     #[must_use]
-    pub fn new_with_dns(
+    pub fn new(
         server_ip: Ipv4Addr,
         subnet_mask: Ipv4Addr,
         router: Ipv4Addr,
@@ -720,7 +590,6 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
             ip_pool_start,
             ip_pool_end,
             lease_time: DEFAULT_LEASE_TIME,
-            socket_buffer_size: DEFAULT_SOCKET_BUFFER_SIZE,
         };
         Self {
             config,
@@ -728,19 +597,7 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
         }
     }
 
-    /// Creates a new DHCP server with advanced configuration options
-    ///
-    /// This method provides more flexibility than the basic `new` method,
-    /// allowing configuration of multiple DNS servers, custom lease times,
-    /// and other advanced options.
-    ///
-    /// # Arguments
-    ///
-    /// * `config` - DHCP server configuration
-    ///
-    /// # Returns
-    ///
-    /// A new `DhcpServer` instance ready to handle DHCP requests
+    /// Creates a new DHCP server from a [`DhcpConfig`].
     ///
     /// # Examples
     ///
@@ -761,23 +618,42 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     /// ```
     #[must_use]
     pub const fn with_config(config: DhcpConfig<MAX_DNS>) -> Self {
-        let leases = IndexMap::new();
-        Self { config, leases }
+        Self {
+            config,
+            leases: IndexMap::new(),
+        }
     }
 
-    /// Gets a reference to the current configuration
+    /// Gets a reference to the current configuration.
     #[must_use]
     pub const fn config(&self) -> &DhcpConfig<MAX_DNS> {
         &self.config
     }
 
-    /// Gets the current lease count
+    /// Gets the current number of active leases.
     #[must_use]
     pub fn lease_count(&self) -> usize {
         self.leases.len()
     }
 
-    /// Checks if the IP pool is full
+    /// Removes all expired leases from the lease table.
+    pub fn purge_expired_leases(&mut self) {
+        let now = embassy_time::Instant::now().as_millis();
+        let mut expired: Vec<[u8; 6], MAX_CLIENTS> = Vec::new();
+        for (mac, entry) in &self.leases {
+            if entry.expires_at <= now {
+                let _ = expired.push(*mac);
+            }
+        }
+        for mac in &expired {
+            self.leases.remove(mac);
+        }
+    }
+
+    /// Checks if the IP pool is full.
+    ///
+    /// Call [`purge_expired_leases`](Self::purge_expired_leases) first
+    /// to reclaim expired entries if desired.
     #[must_use]
     pub fn is_pool_full(&self) -> bool {
         let pool_size =
@@ -785,24 +661,16 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
         self.leases.len() >= (pool_size as usize).min(MAX_CLIENTS)
     }
 
-    /// Finds the next available IP address in the configured pool
-    ///
-    /// Iterates through the IP address range from `ip_pool_start` to `ip_pool_end`
-    /// and returns the first IP address that is not currently leased to a client.
-    ///
-    /// # Returns
-    ///
-    /// * `Some(Ipv4Addr)` - The next available IP address
-    /// * `None` - If all IP addresses in the pool are currently leased
+    /// Finds the next available IP address in the configured pool.
     ///
     /// # Example
     ///
     /// ```rust
     /// use core::net::Ipv4Addr;
     /// use leasehund::{DhcpConfig, DhcpServer};
-    /// use heapless::Vec;
-    /// let mut dns_servers = heapless::Vec::<core::net::Ipv4Addr, 4>::new();
-    /// dns_servers.push(core::net::Ipv4Addr::new(1, 1, 1, 1)).ok();
+    ///
+    /// let mut dns_servers = heapless::Vec::<Ipv4Addr, 4>::new();
+    /// dns_servers.push(Ipv4Addr::new(1, 1, 1, 1)).ok();
     /// let config: DhcpConfig<4> = DhcpConfig {
     ///     server_ip: Ipv4Addr::new(10, 0, 0, 1),
     ///     subnet_mask: Ipv4Addr::new(255, 255, 255, 0),
@@ -811,7 +679,6 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     ///     ip_pool_start: Ipv4Addr::new(10, 0, 0, 100),
     ///     ip_pool_end: Ipv4Addr::new(10, 0, 0, 102),
     ///     lease_time: 3600,
-    ///     socket_buffer_size: 1024,
     /// };
     /// let server: DhcpServer<32, 4> = DhcpServer::with_config(config);
     /// let next = server.get_next_available_ip();
@@ -825,21 +692,7 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
             .find(|ip| !self.leases.values().any(|lease| lease.ip == *ip))
     }
 
-    /// Parses the DHCP message type from the options field
-    ///
-    /// Searches through the DHCP options to find the Message Type option (53)
-    /// and returns its value. This is used to determine what type of DHCP
-    /// message was received (DISCOVER, REQUEST, etc.).
-    ///
-    /// # Arguments
-    ///
-    /// * `options` - Byte slice containing the DHCP options data
-    ///
-    /// # Returns
-    ///
-    /// * `Some(u8)` - The DHCP message type if found
-    /// * `None` - If the message type option is not present or malformed
-    #[allow(clippy::unused_self)]
+    /// Parses the DHCP message type from the options field.
     fn parse_message_type(options: &[u8]) -> Option<u8> {
         let mut i = 0;
         while i < options.len() {
@@ -858,21 +711,7 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
         None
     }
 
-    /// Adds standard DHCP options to a response packet
-    ///
-    /// Appends the following options to the packet:
-    /// - Message Type (53)
-    /// - Server Identifier (54) - This server's IP address
-    /// - Subnet Mask (1)
-    /// - Router (3) - Default gateway
-    /// - Domain Name Server (6) - DNS server
-    /// - IP Address Lease Time (51)
-    /// - End option (255)
-    ///
-    /// # Arguments
-    ///
-    /// * `packet` - Mutable reference to the packet buffer
-    /// * `msg_type` - DHCP message type to include in options
+    /// Appends standard DHCP options to a response packet.
     fn add_options(&self, packet: &mut Vec<u8, DHCP_PACKET_SIZE>, msg_type: u8) {
         packet
             .extend_from_slice(&[OPTION_MESSAGE_TYPE, 1, msg_type])
@@ -886,18 +725,16 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
             .extend_from_slice(&self.config.subnet_mask.octets())
             .ok();
 
-        // Add router option if configured
         if let Some(router) = self.config.router {
             packet.extend_from_slice(&[OPTION_ROUTER, 4]).ok();
             packet.extend_from_slice(&router.octets()).ok();
         }
 
-        // Add DNS servers (support multiple)
         if !self.config.dns_servers.is_empty() {
-            let dns_count = self.config.dns_servers.len() * 4; // 4 bytes per IP
-            let dns_count_u8 = u8::try_from(dns_count).unwrap_or_default();
+            let dns_len = self.config.dns_servers.len() * 4;
+            let dns_len_u8 = u8::try_from(dns_len).unwrap_or_default();
             packet
-                .extend_from_slice(&[OPTION_DNS_SERVER, dns_count_u8])
+                .extend_from_slice(&[OPTION_DNS_SERVER, dns_len_u8])
                 .ok();
             for dns in &self.config.dns_servers {
                 packet.extend_from_slice(&dns.octets()).ok();
@@ -911,19 +748,7 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
         packet.extend_from_slice(&[OPTION_END]).ok();
     }
 
-    /// Creates a DHCP response packet
-    ///
-    /// Builds a properly formatted DHCP response packet based on the request
-    /// and message type. Handles IP address assignment for OFFER and ACK messages.
-    ///
-    /// # Arguments
-    ///
-    /// * `req` - The incoming DHCP request packet
-    /// * `msg_type` - Type of response to create (OFFER or ACK)
-    ///
-    /// # Returns
-    ///
-    /// A `Vec` containing the serialized DHCP response packet
+    /// Creates a DHCP response packet.
     fn make_response(&mut self, req: &DhcpPacket, msg_type: u8) -> Vec<u8, DHCP_PACKET_SIZE> {
         let mut resp = DhcpPacket {
             op: 2, // BOOTREPLY
@@ -935,10 +760,18 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
         };
         resp.chaddr[..6].copy_from_slice(&req.chaddr[..6]);
         let mac = req.chaddr[..6].try_into().unwrap_or([0; 6]);
+
         match msg_type {
             DHCP_OFFER => {
                 if let Some(ip) = self.get_next_available_ip() {
                     resp.yiaddr = ip.octets();
+                    // Reserve with a short TTL to prevent duplicate offers.
+                    let reservation = LeaseEntry {
+                        ip,
+                        mac,
+                        expires_at: embassy_time::Instant::now().as_millis() + OFFER_RESERVATION_MS,
+                    };
+                    let _ = self.leases.insert(mac, reservation);
                 }
             }
             DHCP_ACK => {
@@ -946,103 +779,93 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
                     resp.yiaddr = lease.ip.octets();
                 } else if let Some(ip) = self.get_next_available_ip() {
                     resp.yiaddr = ip.octets();
-                    let lease = LeaseEntry {
-                        ip,
-                        mac,
-                        lease_time: embassy_time::Instant::now().as_millis()
-                            + (u64::from(self.config.lease_time) * 1000),
-                    };
-                    let _ = self.leases.insert(mac, lease);
                 }
+                // (Re-)insert with the full lease duration.
+                let ip = Ipv4Addr::from(resp.yiaddr);
+                let lease = LeaseEntry {
+                    ip,
+                    mac,
+                    expires_at: embassy_time::Instant::now().as_millis()
+                        + (u64::from(self.config.lease_time) * 1000),
+                };
+                let _ = self.leases.insert(mac, lease);
             }
             _ => {}
         }
+
         let mut bytes = Vec::<u8, DHCP_PACKET_SIZE>::new();
-        unsafe {
-            let resp_bytes = core::slice::from_raw_parts(
-                (&raw const resp).cast::<u8>(),
-                core::mem::size_of::<DhcpPacket>(),
-            );
-            bytes.extend_from_slice(resp_bytes).ok();
-        }
+        // Safe serialization of a packed struct: transmute to a byte array
+        // avoids alignment issues that from_raw_parts would have.
+        let resp_bytes: [u8; FIXED_PART_SIZE] = unsafe { core::mem::transmute(resp) };
+        bytes.extend_from_slice(&resp_bytes).ok();
         self.add_options(&mut bytes, msg_type);
         bytes
     }
 
-    /// Handles an incoming DHCP packet
-    ///
-    /// Processes incoming DHCP messages and generates appropriate responses:
-    /// - DISCOVER messages receive OFFER responses
-    /// - REQUEST messages receive ACK responses  
-    /// - RELEASE messages trigger lease removal
-    ///
-    /// # Arguments
-    ///
-    /// * `socket` - UDP socket for sending responses
-    /// * `data` - Raw packet data received from client
+    /// Handles an incoming DHCP packet.
     #[allow(clippy::future_not_send)]
     async fn handle_packet(
         &mut self,
         socket: &DHCPServerSocket<'_>,
         data: &[u8],
     ) -> Option<TransactionEvent> {
-        if data.len() < core::mem::size_of::<DhcpPacket>() {
+        // Reclaim expired leases before processing.
+        self.purge_expired_leases();
+
+        if data.len() < FIXED_PART_SIZE {
             return None;
         }
-        let packet = unsafe { &*data.as_ptr().cast::<DhcpPacket>() };
+
+        // SAFETY: read_unaligned handles the packed struct without alignment requirements.
+        // We verified data.len() >= FIXED_PART_SIZE above.
+        let packet = unsafe { core::ptr::read_unaligned(data.as_ptr().cast::<DhcpPacket>()) };
         if packet.magic != DHCP_MAGIC {
             return None;
         }
-        let options = &data[core::mem::size_of::<DhcpPacket>()..];
-        if let Some(msg_type) = Self::parse_message_type(options) {
-            match msg_type {
-                DHCP_DISCOVER => {
-                    let resp = self.make_response(packet, DHCP_OFFER);
-                    let meta = embassy_net::udp::UdpMetadata {
-                        endpoint: (Ipv4Addr::BROADCAST, DHCP_CLIENT_PORT).into(),
-                        local_address: None,
-                        meta: PacketMeta::default(),
-                    };
-                    let _ = socket.socket.send_to(&resp, meta).await;
-                    return None;
-                }
-                DHCP_REQUEST => {
-                    let resp = self.make_response(packet, DHCP_ACK);
-                    let meta = embassy_net::udp::UdpMetadata {
-                        endpoint: (Ipv4Addr::BROADCAST, DHCP_CLIENT_PORT).into(),
-                        local_address: None,
-                        meta: PacketMeta::default(),
-                    };
-                    let _ = socket.socket.send_to(&resp, meta).await;
-                    let mac: [u8; 6] = packet.chaddr[..6].try_into().unwrap_or([0; 6]);
-                    return self
-                        .leases
-                        .get(&mac)
-                        .map(|entry| TransactionEvent::Leased(entry.ip, mac));
-                }
-                DHCP_RELEASE => {
-                    let mac: [u8; 6] = packet.chaddr[..6].try_into().unwrap_or([0; 6]);
-                    let entry = self.leases.remove(&mac);
-                    return entry.map(|entry| TransactionEvent::Released(entry.ip, entry.mac));
-                }
-                _ => {
-                    return None;
-                }
+
+        let options = &data[FIXED_PART_SIZE..];
+        let msg_type = Self::parse_message_type(options)?;
+
+        // Consolidate DISCOVER/REQUEST into a single .await point.
+        let (resp, event) = match msg_type {
+            DHCP_DISCOVER => (Some(self.make_response(&packet, DHCP_OFFER)), None),
+            DHCP_REQUEST => {
+                let resp = self.make_response(&packet, DHCP_ACK);
+                let mac: [u8; 6] = packet.chaddr[..6].try_into().unwrap_or([0; 6]);
+                let event = self
+                    .leases
+                    .get(&mac)
+                    .map(|entry| TransactionEvent::Leased(entry.ip, mac));
+                (Some(resp), event)
             }
+            DHCP_RELEASE => {
+                let mac: [u8; 6] = packet.chaddr[..6].try_into().unwrap_or([0; 6]);
+                let entry = self.leases.remove(&mac);
+                return entry.map(|e| TransactionEvent::Released(e.ip, e.mac));
+            }
+            _ => return None,
+        };
+
+        if let Some(resp) = resp {
+            let meta = embassy_net::udp::UdpMetadata {
+                endpoint: (Ipv4Addr::BROADCAST, DHCP_CLIENT_PORT).into(),
+                local_address: None,
+                meta: PacketMeta::default(),
+            };
+            let _ = socket.socket.send_to(&resp, meta).await;
         }
-        None
+
+        event
     }
 
-    /// Runs the DHCP server until a single lease/release transaction occurs
-    /// This function listens for incoming DHCP packets and processes them.
-    /// It is typically called in a loop to handle multiple lease/release transactions.
-    /// # Arguments
-    /// * `socket` - The `DHCPServerSocket` which is actually a properly configured UDP socket to listen on for DHCP packets
-    /// # Returns
-    /// - Ok([`TransactionEvent`]) if a transaction was successfully processed
+    /// Processes packets until a single lease or release transaction completes.
+    ///
     /// # Errors
-    /// - Err([`RecvError`]) if there was an error of receiving a packet
+    ///
+    /// Returns [`RecvError`] if there was an error receiving a packet.
+    ///
     /// # Examples
+    ///
     /// ```rust
     /// use leasehund::{DhcpServer, DHCPServerBuffers, DHCPServerSocket, TransactionEvent};
     /// # use embassy_net::Stack;
@@ -1062,7 +885,6 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     /// let _event: Result<TransactionEvent, _> = server.lease_one(&mut socket).await;
     /// # }
     /// ```
-    ///
     #[allow(clippy::future_not_send)]
     pub async fn lease_one(
         &mut self,
@@ -1073,40 +895,20 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
             match socket.socket.recv_from(&mut buf).await {
                 Ok((len, _)) => {
                     if let Some(event) = self.handle_packet(socket, &buf[..len]).await {
-                        // Ensure all data is flushed to the network
                         socket.socket.flush().await;
                         return Ok(event);
                     }
                 }
-
                 Err(e) => return Err(e),
             }
         }
     }
 
-    /// Runs the DHCP server on the provided network stack
-    ///
-    /// This method starts the DHCP server and runs indefinitely, listening for
-    /// incoming DHCP requests on UDP port 67. It handles the complete DHCP
-    /// transaction lifecycle including DISCOVER, REQUEST, and RELEASE messages.
-    ///
-    /// The server will:
-    /// - Bind to UDP port 67 (standard DHCP server port)
-    /// - Listen for incoming DHCP messages
-    /// - Process requests and send appropriate responses
-    /// - Manage IP address leases automatically
-    ///
-    /// # Arguments
-    ///
-    /// * `stack` - Embassy network stack instance for network operations
-    ///
-    /// # Returns
-    ///
-    /// This function never returns (marked with `!`) as it runs in an infinite loop
+    /// Runs the DHCP server forever on the provided network stack.
     ///
     /// # Panics
     ///
-    /// Panics if the UDP socket cannot bind to the DHCP server port (67)
+    /// Panics if the UDP socket cannot bind to port 67.
     ///
     /// # Examples
     ///
@@ -1125,7 +927,6 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     ///     Ipv4Addr::new(192, 168, 1, 200),
     /// );
     ///
-    /// // This will run forever
     /// server.run(stack).await;
     /// # }
     /// ```
@@ -1154,16 +955,14 @@ mod tests {
     type TestBuilder = super::DhcpConfigBuilder<2>;
 
     #[test]
-    fn dhcp_config_builder_basic() {
+    fn config_builder_basic() {
         let config = TestBuilder::new()
-            .clear_dns_servers()
             .server_ip(Ipv4Addr::new(10, 0, 0, 1))
             .subnet_mask(Ipv4Addr::new(255, 255, 255, 0))
             .router(Ipv4Addr::new(10, 0, 0, 254))
             .add_dns_server(Ipv4Addr::new(8, 8, 8, 8))
             .ip_pool(Ipv4Addr::new(10, 0, 0, 100), Ipv4Addr::new(10, 0, 0, 200))
             .lease_time(3600)
-            .socket_buffer_size(2048)
             .build();
         assert_eq!(config.server_ip, Ipv4Addr::new(10, 0, 0, 1));
         assert_eq!(config.subnet_mask, Ipv4Addr::new(255, 255, 255, 0));
@@ -1173,12 +972,23 @@ mod tests {
         assert_eq!(config.ip_pool_start, Ipv4Addr::new(10, 0, 0, 100));
         assert_eq!(config.ip_pool_end, Ipv4Addr::new(10, 0, 0, 200));
         assert_eq!(config.lease_time, 3600);
-        assert_eq!(config.socket_buffer_size, 2048);
     }
 
     #[test]
-    fn dhcp_server_new_with_dns() {
-        let server = TestServer::new_with_dns(
+    fn config_builder_starts_with_no_dns() {
+        let config = TestBuilder::new().build();
+        assert!(config.dns_servers.is_empty());
+    }
+
+    #[test]
+    fn config_builder_no_router() {
+        let config = TestBuilder::new().no_router().build();
+        assert_eq!(config.router, None);
+    }
+
+    #[test]
+    fn server_new() {
+        let server = TestServer::new(
             Ipv4Addr::new(192, 168, 1, 1),
             Ipv4Addr::new(255, 255, 255, 0),
             Ipv4Addr::new(192, 168, 1, 1),
@@ -1193,8 +1003,8 @@ mod tests {
     }
 
     #[test]
-    fn dhcp_server_ip_pool_full() {
-        let mut server = TestServer::new_with_dns(
+    fn ip_pool_full() {
+        let mut server = TestServer::new(
             Ipv4Addr::new(10, 0, 0, 1),
             Ipv4Addr::new(255, 255, 255, 0),
             Ipv4Addr::new(10, 0, 0, 1),
@@ -1202,13 +1012,12 @@ mod tests {
             Ipv4Addr::new(10, 0, 0, 100),
             Ipv4Addr::new(10, 0, 0, 101),
         );
-        // Simulate two leases (pool size = 2)
         for i in 0..2 {
             let mac = [0, 0, 0, 0, 0, i];
             let lease = super::LeaseEntry {
                 ip: Ipv4Addr::new(10, 0, 0, 100 + i),
                 mac,
-                lease_time: 123_456,
+                expires_at: u64::MAX,
             };
             let _ = server.leases.insert(mac, lease);
         }
@@ -1216,7 +1025,7 @@ mod tests {
     }
 
     #[test]
-    fn dhcp_config_default_values() {
+    fn config_default_values() {
         let config = TestConfig::default();
         assert_eq!(config.server_ip, Ipv4Addr::new(192, 168, 1, 1));
         assert_eq!(config.subnet_mask, Ipv4Addr::new(255, 255, 255, 0));
@@ -1226,6 +1035,68 @@ mod tests {
         assert_eq!(config.ip_pool_start, Ipv4Addr::new(192, 168, 1, 100));
         assert_eq!(config.ip_pool_end, Ipv4Addr::new(192, 168, 1, 200));
         assert_eq!(config.lease_time, super::DEFAULT_LEASE_TIME);
-        assert_eq!(config.socket_buffer_size, super::DEFAULT_SOCKET_BUFFER_SIZE);
+    }
+
+    #[test]
+    fn get_next_available_ip_empty() {
+        let server = TestServer::new(
+            Ipv4Addr::new(10, 0, 0, 1),
+            Ipv4Addr::new(255, 255, 255, 0),
+            Ipv4Addr::new(10, 0, 0, 1),
+            Ipv4Addr::new(1, 1, 1, 1),
+            Ipv4Addr::new(10, 0, 0, 100),
+            Ipv4Addr::new(10, 0, 0, 101),
+        );
+        assert_eq!(
+            server.get_next_available_ip(),
+            Some(Ipv4Addr::new(10, 0, 0, 100))
+        );
+    }
+
+    #[test]
+    fn get_next_available_ip_skips_leased() {
+        let mut server = TestServer::new(
+            Ipv4Addr::new(10, 0, 0, 1),
+            Ipv4Addr::new(255, 255, 255, 0),
+            Ipv4Addr::new(10, 0, 0, 1),
+            Ipv4Addr::new(1, 1, 1, 1),
+            Ipv4Addr::new(10, 0, 0, 100),
+            Ipv4Addr::new(10, 0, 0, 101),
+        );
+        let mac = [0, 0, 0, 0, 0, 1];
+        let lease = super::LeaseEntry {
+            ip: Ipv4Addr::new(10, 0, 0, 100),
+            mac,
+            expires_at: u64::MAX,
+        };
+        let _ = server.leases.insert(mac, lease);
+        assert_eq!(
+            server.get_next_available_ip(),
+            Some(Ipv4Addr::new(10, 0, 0, 101))
+        );
+    }
+
+    #[test]
+    fn parse_message_type_discover() {
+        let options = [
+            super::OPTION_MESSAGE_TYPE,
+            1,
+            super::DHCP_DISCOVER,
+            super::OPTION_END,
+        ];
+        assert_eq!(
+            TestServer::parse_message_type(&options),
+            Some(super::DHCP_DISCOVER)
+        );
+    }
+
+    #[test]
+    fn parse_message_type_empty() {
+        assert_eq!(TestServer::parse_message_type(&[]), None);
+    }
+
+    #[test]
+    fn parse_message_type_end_only() {
+        assert_eq!(TestServer::parse_message_type(&[super::OPTION_END]), None);
     }
 }


### PR DESCRIPTION
## Breaking Changes

- **Remove `new_with_dns()`**: `new()` now accepts a `dns_server` parameter (identical signature to old `new_with_dns`)
- **Remove `socket_buffer_size`** from `DhcpConfig` (unused)
- **Rename** `LeaseEntry.lease_time` → `expires_at`

## Soundness Fixes

- Fix UB: use `read_unaligned` for packed `DhcpPacket` deserialization (was `&*ptr.cast()`)
- Fix UB: use `transmute` for packed `DhcpPacket` serialization (was `from_raw_parts`)
- Fix DNS servers silently ignored in `new()` constructor

## New Features

- `purge_expired_leases()` — automatically called before each allocation
- OFFER reservation: offered IPs reserved with 60s TTL to prevent duplicate offers

## Improvements

- Consolidate two `send_to().await` into one (reduces async future size)
- Remove stale `#[allow(clippy::unused_self)]` and `#[allow(dead_code)]`
- `DhcpConfigBuilder::new()` starts with empty DNS servers (not inherited from Default)

## Migration

```rust
// Before
let server = DhcpServer::new_with_dns(ip, mask, router, dns, pool_start, pool_end);
// After
let server = DhcpServer::new(ip, mask, router, dns, pool_start, pool_end);
```
