### PR TITLE
feat: add run_with_callback for lease events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-06-03
+
+### Added
+
+- `DhcpServer::run_with_callback()` — runs the DHCP server forever while invoking a caller-provided callback for every `TransactionEvent` (lease assigned, lease released). This allows downstream code to react to DHCP lifecycle events without replacing the built-in `run()` loop.
+
 ## [0.5.0] - 2026-05-24
 
 ### Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leasehund"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 authors = ["rttf <contact@rttf.dev>"]
 description = "A lightweight, embedded-friendly DHCP server implementation for Rust no_std environments"

--- a/README.md
+++ b/README.md
@@ -167,6 +167,45 @@ async fn main(_spawner: Spawner) {
 }
 ```
 
+### Event Callbacks
+
+If you want the convenience of `run()` but still need to react to lease events, use `run_with_callback()`:
+
+```rust
+use core::net::Ipv4Addr;
+use leasehund::{DhcpServer, DhcpConfigBuilder, TransactionEvent};
+use embassy_net::Stack;
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let stack = /* ... your network stack initialization ... */;
+
+    let config = DhcpConfigBuilder::<4>::new()
+        .server_ip(Ipv4Addr::new(10, 0, 1, 1))
+        .subnet_mask(Ipv4Addr::new(255, 255, 0, 0))
+        .no_router()
+        .add_dns_server(Ipv4Addr::new(8, 8, 8, 8))
+        .ip_pool(Ipv4Addr::new(10, 0, 100, 1), Ipv4Addr::new(10, 0, 199, 254))
+        .lease_time(7200)
+        .build();
+
+    let mut server: DhcpServer<32, 4> = DhcpServer::with_config(config);
+
+    server.run_with_callback(stack, |event| {
+        match event {
+            TransactionEvent::Leased(ip, mac) => {
+                info!("New lease: {} -> {:02x?}", ip, mac);
+            }
+            TransactionEvent::Released(ip, mac) => {
+                info!("Lease released: {} -> {:02x?}", ip, mac);
+            }
+        }
+    }).await;
+}
+```
+
+This is ideal for logging, metrics, or triggering side effects (e.g., opening a firewall pinhole) when a host gets a DHCP lease.
+
 ## Protocol Compliance
 
 Leasehund is compliant with [RFC 2131](https://www.rfc-editor.org/rfc/rfc2131) and [RFC 2132](https://www.rfc-editor.org/rfc/rfc2132). All DHCP packets include and check the required DHCP magic cookie (0x63825363, see [RFC 2132 section 2](https://www.rfc-editor.org/rfc/rfc2132#section-2)) for strict standards compliance.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -932,13 +932,57 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
     /// ```
     #[allow(clippy::future_not_send)]
     pub async fn run(&mut self, stack: Stack<'_>) -> ! {
+        self.run_with_callback(stack, |_| {}).await
+    }
+
+    /// Runs the DHCP server forever, invoking `callback` for every lease event.
+    ///
+    /// This is identical to [`run`](Self::run) except that `TransactionEvent`s
+    /// are forwarded to the caller via `callback` instead of being discarded.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use embassy_net::Stack;
+    /// use leasehund::{DhcpServer, TransactionEvent};
+    /// use core::net::Ipv4Addr;
+    ///
+    /// # async fn example(stack: Stack<'static>) {
+    /// let mut server = DhcpServer::<32, 4>::new(
+    ///     Ipv4Addr::new(192, 168, 1, 1),
+    ///     Ipv4Addr::new(255, 255, 255, 0),
+    ///     Ipv4Addr::new(192, 168, 1, 1),
+    ///     Ipv4Addr::new(8, 8, 8, 8),
+    ///     Ipv4Addr::new(192, 168, 1, 100),
+    ///     Ipv4Addr::new(192, 168, 1, 200),
+    /// );
+    ///
+    /// server.run_with_callback(stack, |event| {
+    ///     match event {
+    ///         TransactionEvent::Leased(ip, mac) => {
+    ///             // log or react to new lease
+    ///         }
+    ///         TransactionEvent::Released(ip, mac) => {
+    ///             // log or react to release
+    ///         }
+    ///     }
+    /// }).await;
+    /// # }
+    /// ```
+    #[allow(clippy::future_not_send)]
+    pub async fn run_with_callback<F>(&mut self, stack: Stack<'_>, mut callback: F) -> !
+    where
+        F: FnMut(TransactionEvent),
+    {
         let mut buffers = DHCPServerBuffers::new();
         let socket = DHCPServerSocket::new(stack, &mut buffers);
         loop {
             let mut buf = [0u8; DHCP_PACKET_SIZE];
             match socket.socket.recv_from(&mut buf).await {
                 Ok((len, _)) => {
-                    let _ = self.handle_packet(&socket, &buf[..len]).await;
+                    if let Some(event) = self.handle_packet(&socket, &buf[..len]).await {
+                        callback(event);
+                    }
                 }
                 Err(_) => Timer::after(Duration::from_millis(100)).await,
             }


### PR DESCRIPTION
Adds `DhcpServer::run_with_callback(stack, callback)` which runs the server loop forever while invoking the provided closure for every `TransactionEvent` (Leased / Released).

This lets downstream code react to DHCP lifecycle events (logging, metrics, firewall pinholes) without replacing the built-in `run()` loop or manually calling `lease_one()`.

CHANGELOG and README updated. Patch bump 0.5.0 → 0.5.1.