### PR TITLE
Release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2026-06-22
+
+### Fixed
+
+- Flush the UDP socket after handling packets in `DhcpServer::run_with_callback()`. Without this, DHCP OFFER/ACK responses could remain buffered and clients would self-assign link-local addresses instead of receiving leases.
+
 ## [0.5.1] - 2026-06-03
 
 ### Added
@@ -86,3 +92,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Embassy async runtime integration
 - Configurable IP pools and lease management
 - Essential DHCP options support (subnet mask, router, DNS)
+
+[0.5.2]: https://github.com/rttfd/leasehund/compare/v0.5.1...v0.5.2
+[0.5.1]: https://github.com/rttfd/leasehund/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/rttfd/leasehund/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/rttfd/leasehund/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/rttfd/leasehund/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/rttfd/leasehund/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/rttfd/leasehund/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leasehund"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 authors = ["rttf <contact@rttf.dev>"]
 description = "A lightweight, embedded-friendly DHCP server implementation for Rust no_std environments"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -975,7 +975,7 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
         F: FnMut(TransactionEvent),
     {
         let mut buffers = DHCPServerBuffers::new();
-        let socket = DHCPServerSocket::new(stack, &mut buffers);
+        let mut socket = DHCPServerSocket::new(stack, &mut buffers);
         loop {
             let mut buf = [0u8; DHCP_PACKET_SIZE];
             match socket.socket.recv_from(&mut buf).await {
@@ -983,6 +983,7 @@ impl<const MAX_CLIENTS: usize, const MAX_DNS: usize> DhcpServer<MAX_CLIENTS, MAX
                     if let Some(event) = self.handle_packet(&socket, &buf[..len]).await {
                         callback(event);
                     }
+                    socket.socket.flush().await;
                 }
                 Err(_) => Timer::after(Duration::from_millis(100)).await,
             }


### PR DESCRIPTION
## Summary
- bump leasehund to 0.5.2
- flush UDP socket after DHCP packet handling in run_with_callback
- add CHANGELOG entry and comparison links

## Verification
- make ci
- make publish-dry-run

## Notes
This fixes clients self-assigning 169.254.x.x addresses when using run_with_callback because DHCP OFFER/ACK replies could remain buffered.